### PR TITLE
Redesign shopping list with unit conversion, waste optimization, and multi-product support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,23 @@ This applies to new features, bug fixes, and refactors. Do not write production 
   - `Menu.allIngredients(recipes:)`: Aggregate all ingredients across meals (respects yields)
   - `MenuConfiguration.canBeCookedAtTheSpot`: Derived from time availability
 
+### Adding or Editing Products (mandatory)
+
+When adding a new Product to an Ingredient or editing an existing one, **always look up the product on the Mercadona API** to fill all fields accurately. Do not guess weights, pack sizes, or shelf life.
+
+1. Extract the product ID from the Mercadona URL (e.g., `https://tienda.mercadona.es/product/20559/...` -> ID `20559`)
+2. Fetch `https://tienda.mercadona.es/api/products/{id}/`
+3. Map the API response to Product fields:
+   - `link` = `share_url`
+   - `itemsPerPack` = `price_instructions.total_units` (or 1 if null/not a pack)
+   - `quantityPerItem`: if `is_pack`, use `pack_size * 1000` (kg->g) or `pack_size * 100` (l->cl). If not a pack, use `unit_size * 1000` (kg->g) or `unit_size * 100` (l->cl)
+   - `unit` = `grams` if `size_format == "kg"`, `centiliters` if `size_format == "l"`, `pieces` if sold by unit
+   - `shelfLifeDays` = parse from `details.storage_instructions` (look for "consumir en N dias"). Null if not found or non-perishable
+4. For non-Mercadona products (e.g., Carrefour), manually research the product page for equivalent data
+5. Verify the computed `totalQuantityPerPack` (itemsPerPack * quantityPerItem) matches `unit_size * 1000` from the API
+
+See the [Mercadona API reference](https://github.com/datania/mercadona-catalog/blob/main/api.md) for full endpoint documentation. User's postal code: 08901.
+
 ### Search
 - `normalizeForSearch()` extension (in `flutter_essentials/`) with optional space removal
 - Applied consistently to ingredient and recipe search/filter

--- a/menu_management/assets/RecipeBook.tsr
+++ b/menu_management/assets/RecipeBook.tsr
@@ -34,7 +34,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.2
     },
     {
       "id": "7722a1d0-5ae8-1e99-9cbf-85317f03e969",
@@ -46,7 +47,8 @@
           "quantityPerItem": 300,
           "unit": "centiliters"
         }
-      ]
+      ],
+      "density": 0.91
     },
     {
       "id": "2939e4b0-6b1e-1e99-9cbf-85317f03e969",
@@ -116,7 +118,8 @@
           "link": "https://tienda.mercadona.es/product/18002/atun-claro-aceite-oliva-hacendado-pack-6",
           "itemsPerPack": 6,
           "quantityPerItem": 60,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 1
         }
       ]
     },
@@ -128,13 +131,15 @@
           "link": "https://tienda.mercadona.es/product/16714/maiz-dulce-hacendado-pack-3",
           "itemsPerPack": 3,
           "quantityPerItem": 70,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         },
         {
           "link": "https://tienda.mercadona.es/product/16712/maiz-dulce-hacendado-pack-3",
           "itemsPerPack": 3,
           "quantityPerItem": 140,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -152,7 +157,8 @@
           "link": "https://tienda.mercadona.es/product/52406/queso-fresco-burgos-natural-hacendado-pack-2",
           "itemsPerPack": 2,
           "quantityPerItem": 250,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 3
         }
       ]
     },
@@ -164,13 +170,15 @@
           "link": "https://tienda.mercadona.es/product/23217/aceitunas-manzanilla-rellenas-anchoa-hacendado-pack-3",
           "itemsPerPack": 3,
           "quantityPerItem": 50,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 14
         },
         {
           "link": "https://tienda.mercadona.es/product/22910/aceitunas-manzanilla-rellenas-anchoa-hacendado-pack-3",
           "itemsPerPack": 3,
           "quantityPerItem": 150,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 14
         }
       ]
     },
@@ -184,7 +192,8 @@
           "quantityPerItem": 150,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.33
     },
     {
       "id": "43705180-786a-1e99-9cbf-85317f03e969",
@@ -202,7 +211,8 @@
           "quantityPerItem": 125,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "2eb01ba0-7896-1e99-9cbf-85317f03e969",
@@ -236,7 +246,8 @@
           "link": "https://tienda.mercadona.es/product/87203/escalopin-salmon-bandeja",
           "itemsPerPack": 4,
           "quantityPerItem": 87.5,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 1
         }
       ]
     },
@@ -248,9 +259,11 @@
           "link": "https://tienda.mercadona.es/product/10730/leche-desnatada-sin-lactosa-hacendado-pack-6",
           "itemsPerPack": 6,
           "quantityPerItem": 100,
-          "unit": "centiliters"
+          "unit": "centiliters",
+          "shelfLifeDays": 3
         }
-      ]
+      ],
+      "density": 1.03
     },
     {
       "id": "671f3ca0-8746-1e99-9cbf-85317f03e969",
@@ -340,7 +353,8 @@
           "quantityPerItem": 100,
           "unit": "centiliters"
         }
-      ]
+      ],
+      "density": 0.91
     },
     {
       "id": "9a648f10-86be-1eaa-b835-cfe533d41a10",
@@ -362,7 +376,8 @@
           "link": "https://tienda.mercadona.es/product/33189/jalapenos-picantes-hacendado-vinagre-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 60,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 15
         }
       ]
     },
@@ -376,7 +391,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.83
     },
     {
       "id": "92057590-8a48-1eaa-b835-cfe533d41a10",
@@ -388,7 +404,8 @@
           "quantityPerItem": 25,
           "unit": "centiliters"
         }
-      ]
+      ],
+      "density": 1.2
     },
     {
       "id": "ba455b80-8a73-1eaa-b835-cfe533d41a10",
@@ -400,7 +417,8 @@
           "quantityPerItem": 100,
           "unit": "centiliters"
         }
-      ]
+      ],
+      "density": 1.01
     },
     {
       "id": "5018a870-8e88-1eaa-b835-cfe533d41a10",
@@ -424,7 +442,8 @@
           "quantityPerItem": 150,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.6
     },
     {
       "id": "10c0f940-bdb6-1eaa-b835-cfe533d41a10",
@@ -452,7 +471,8 @@
     },
     {
       "id": "20cddb70-c539-1eaa-b835-cfe533d41a10",
-      "name": "Agua"
+      "name": "Agua",
+      "density": 1.0
     },
     {
       "id": "b4523e20-c612-1eaa-b835-cfe533d41a10",
@@ -464,7 +484,8 @@
           "quantityPerItem": 50,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.46
     },
     {
       "id": "31870940-c6d4-1eaa-b835-cfe533d41a10",
@@ -530,7 +551,8 @@
           "quantityPerItem": 76,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.45
     },
     {
       "id": "38bf4b50-21de-1eeb-9b52-298d2e408b19",
@@ -540,9 +562,11 @@
           "link": "https://tienda.mercadona.es/product/17174/leche-coco-dee-thai-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 40,
-          "unit": "centiliters"
+          "unit": "centiliters",
+          "shelfLifeDays": 2
         }
-      ]
+      ],
+      "density": 0.97
     },
     {
       "id": "26942580-276b-1eeb-9b52-298d2e408b19",
@@ -554,7 +578,8 @@
           "quantityPerItem": 49,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.36
     },
     {
       "id": "84493510-2c7c-1eeb-9b52-298d2e408b19",
@@ -564,15 +589,18 @@
           "link": "https://tienda.mercadona.es/product/16044/tomate-triturado-hacendado-freir-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 400,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         },
         {
           "link": "https://tienda.mercadona.es/product/16043/tomate-triturado-hacendado-freir-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 800,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.07
     },
     {
       "id": "c49f4080-2fda-1eeb-9b52-298d2e408b19",
@@ -624,7 +652,8 @@
           "link": "https://tienda.mercadona.es/product/26030/lenteja-cocida-hacendado-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 400,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -726,7 +755,8 @@
           "link": "https://tienda.mercadona.es/product/16618/champinones-laminados-hacendado-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 180,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -750,7 +780,8 @@
           "link": "https://tienda.mercadona.es/product/26029/garbanzo-cocido-hacendado-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 400,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -768,7 +799,8 @@
           "link": "https://tienda.mercadona.es/product/8309/aceitunas-negras-hacendado-rodajas",
           "itemsPerPack": 4,
           "quantityPerItem": 37,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 7
         }
       ]
     },
@@ -780,7 +812,8 @@
           "link": "https://tienda.mercadona.es/product/51197/queso-feta-mezcla-hacendado-dados-tarrina",
           "itemsPerPack": 1,
           "quantityPerItem": 150,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -792,7 +825,8 @@
           "link": "https://tienda.mercadona.es/product/4903/limon-exprimido-hacendado-botella",
           "itemsPerPack": 1,
           "quantityPerItem": 28,
-          "unit": "centiliters"
+          "unit": "centiliters",
+          "shelfLifeDays": 40
         },
         {
           "link": "https://tienda.mercadona.es/product/3210/limon-pieza",
@@ -812,7 +846,8 @@
           "quantityPerItem": 18,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.1
     },
     {
       "id": "e6500b40-41b8-10ba-b0dd-9d041637ca66",
@@ -822,7 +857,8 @@
           "link": "https://tienda.mercadona.es/product/58220/panceta-salada-iberica-hacienda-iberico-paquete",
           "itemsPerPack": 1,
           "quantityPerItem": 360,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 7
         }
       ]
     },
@@ -870,13 +906,15 @@
           "link": "https://tienda.mercadona.es/product/16416/guisantes-extra-hacendado-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 250,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 3
         },
         {
           "link": "https://tienda.mercadona.es/product/16415/guisantes-extra-hacendado-pack-3",
           "itemsPerPack": 3,
           "quantityPerItem": 120,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -902,7 +940,8 @@
           "quantityPerItem": 60,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.46
     },
     {
       "id": "399009c0-6df9-11ef-bbaf-9d5832b648f8",
@@ -912,9 +951,11 @@
           "link": "https://tienda.mercadona.es/product/7032/caldo-verduras-hacendado-brick",
           "itemsPerPack": 1,
           "quantityPerItem": 100,
-          "unit": "centiliters"
+          "unit": "centiliters",
+          "shelfLifeDays": 3
         }
-      ]
+      ],
+      "density": 1.01
     },
     {
       "id": "f768cea0-6df9-11ef-bbaf-9d5832b648f8",
@@ -948,13 +989,15 @@
           "link": "https://tienda.mercadona.es/product/3682/pechugas-enteras-pollo-bandeja",
           "itemsPerPack": 4,
           "quantityPerItem": 300,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 1
         },
         {
           "link": "https://tienda.mercadona.es/product/3724/pechugas-enteras-pollo-bandeja",
           "itemsPerPack": 2,
           "quantityPerItem": 305,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 1
         }
       ]
     },
@@ -968,7 +1011,8 @@
           "quantityPerItem": 58,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.42
     },
     {
       "id": "e2a2ef30-8278-11ef-91e8-3ff59147e22a",
@@ -1004,7 +1048,8 @@
           "quantityPerItem": 57,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.4
     },
     {
       "id": "700c6740-dda8-11ef-99c9-5b6b5cdbe207",
@@ -1014,7 +1059,8 @@
           "link": "https://tienda.mercadona.es/product/26019/alubia-cocida-blanca-hacendado-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 400,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -1026,7 +1072,8 @@
           "link": "https://tienda.mercadona.es/product/6044/butifarra-fresca-bandeja",
           "itemsPerPack": 1,
           "quantityPerItem": 640,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 2
         }
       ]
     },
@@ -1040,7 +1087,8 @@
           "quantityPerItem": 74,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.33
     },
     {
       "id": "9b25caa4-825d-49a7-a3d0-ffa8b82962e3",
@@ -1074,13 +1122,15 @@
           "link": "https://tienda.mercadona.es/product/17131/tomate-frito-receta-artesana-hacendado-con-aceite-oliva-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 300,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         },
         {
           "link": "https://tienda.mercadona.es/product/17163/tomate-frito-receta-artesana-hacendado-con-aceite-oliva-tarro",
           "itemsPerPack": 1,
           "quantityPerItem": 560,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -1110,7 +1160,8 @@
           "link": "https://tienda.mercadona.es/product/2788/muslos-pollo-deshuesados-con-piel-bandeja",
           "itemsPerPack": 1,
           "quantityPerItem": 550,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 1
         }
       ]
     },
@@ -1134,7 +1185,8 @@
           "link": "https://tienda.mercadona.es/product/26110/garbanzos-jardinera-hacendado-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 420,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 5
         }
       ]
     },
@@ -1146,7 +1198,8 @@
           "link": "https://tienda.mercadona.es/product/26101/lentejas-riojana-hacendado-bote",
           "itemsPerPack": 1,
           "quantityPerItem": 420,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 3
         }
       ]
     },
@@ -1158,9 +1211,11 @@
           "link": "https://tienda.mercadona.es/product/7313/caldo-pollo-hacendado-brick",
           "itemsPerPack": 1,
           "quantityPerItem": 100,
-          "unit": "centiliters"
+          "unit": "centiliters",
+          "shelfLifeDays": 3
         }
-      ]
+      ],
+      "density": 1.01
     },
     {
       "id": "9652a688-015f-4771-a630-2439ebb9e168",
@@ -1218,7 +1273,8 @@
           "link": "https://tienda.mercadona.es/product/2622/burger-pollo-bandeja",
           "itemsPerPack": 6,
           "quantityPerItem": 90,
-          "unit": "grams"
+          "unit": "grams",
+          "shelfLifeDays": 2
         }
       ]
     },

--- a/menu_management/assets/RecipeBook.tsr
+++ b/menu_management/assets/RecipeBook.tsr
@@ -10,7 +10,8 @@
           "quantityPerItem": 350,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.4
     },
     {
       "id": "0e622f00-5915-1e99-9cbf-85317f03e969",
@@ -22,7 +23,8 @@
           "quantityPerItem": 720,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "aa9fa790-5a81-1e99-9cbf-85317f03e969",
@@ -60,7 +62,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "b0a1c2d3-e4f5-6789-abcd-ef0123456789",
@@ -72,7 +75,8 @@
           "quantityPerItem": 330,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.1
     },
     {
       "id": "c1b2a3d4-f5e6-7890-bcde-f01234567890",
@@ -84,7 +88,8 @@
           "quantityPerItem": 120,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "1410a8a0-6e0f-1e99-9cbf-85317f03e969",
@@ -96,7 +101,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "7e55ac20-6f80-1e99-9cbf-85317f03e969",
@@ -108,7 +114,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 1.03
     },
     {
       "id": "15b72e30-7419-1e99-9cbf-85317f03e969",
@@ -121,7 +128,8 @@
           "unit": "grams",
           "shelfLifeDays": 1
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "f187e8e0-7479-1e99-9cbf-85317f03e969",
@@ -141,7 +149,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "a4d36d70-7542-1e99-9cbf-85317f03e969",
@@ -160,7 +169,8 @@
           "unit": "grams",
           "shelfLifeDays": 3
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "f9a5b040-75a8-1e99-9cbf-85317f03e969",
@@ -180,7 +190,8 @@
           "unit": "grams",
           "shelfLifeDays": 14
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "06b12da0-776b-1e99-9cbf-85317f03e969",
@@ -224,7 +235,8 @@
           "quantityPerItem": 425,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.35
     },
     {
       "id": "cdf54e80-7ac9-1e99-9cbf-85317f03e969",
@@ -236,7 +248,8 @@
           "quantityPerItem": 170,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "342cd030-8045-1e99-9cbf-85317f03e969",
@@ -249,7 +262,8 @@
           "unit": "grams",
           "shelfLifeDays": 1
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "34d2c7b0-8478-1e99-9cbf-85317f03e969",
@@ -281,7 +295,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.9
     },
     {
       "id": "c4de41c0-8aab-1e99-9cbf-85317f03e969",
@@ -293,7 +308,8 @@
           "quantityPerItem": 240,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "55d45ed0-9ca4-1e99-9cbf-85317f03e969",
@@ -305,7 +321,8 @@
           "quantityPerItem": 600,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "869dc0e0-9deb-1e99-9cbf-85317f03e969",
@@ -317,7 +334,8 @@
           "quantityPerItem": 400,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.7
     },
     {
       "id": "fe0d71c0-8395-1eaa-b835-cfe533d41a10",
@@ -329,7 +347,8 @@
           "quantityPerItem": 550,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "efab4ec0-8428-1eaa-b835-cfe533d41a10",
@@ -341,7 +360,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "a3f7ce50-854e-1eaa-b835-cfe533d41a10",
@@ -366,7 +386,8 @@
           "quantityPerItem": 450,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.92
     },
     {
       "id": "be016180-86e3-1eaa-b835-cfe533d41a10",
@@ -379,7 +400,8 @@
           "unit": "grams",
           "shelfLifeDays": 15
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "7b636a50-8a06-1eaa-b835-cfe533d41a10",
@@ -430,7 +452,8 @@
           "quantityPerItem": 150,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.1
     },
     {
       "id": "fbbadd60-bb47-1eaa-b835-cfe533d41a10",
@@ -455,7 +478,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.5
     },
     {
       "id": "2cc45c00-c4ae-1eaa-b835-cfe533d41a10",
@@ -467,7 +491,8 @@
           "quantityPerItem": 410,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.9
     },
     {
       "id": "20cddb70-c539-1eaa-b835-cfe533d41a10",
@@ -497,7 +522,8 @@
           "quantityPerItem": 500,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "b82ac5f0-7faf-1ec0-9c83-05811f7c00d6",
@@ -527,7 +553,8 @@
           "quantityPerItem": 400,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.85
     },
     {
       "id": "44da8460-2173-1eeb-9b52-298d2e408b19",
@@ -539,7 +566,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "0cf54be0-21c1-1eeb-9b52-298d2e408b19",
@@ -612,7 +640,8 @@
           "quantityPerItem": 166.7,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.7
     },
     {
       "id": "ba1843d0-5949-1eeb-9877-9f2416bff04c",
@@ -624,7 +653,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.96
     },
     {
       "id": "a1aed440-59f2-1eeb-9877-9f2416bff04c",
@@ -642,7 +672,8 @@
           "quantityPerItem": 300,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "33b65330-5a85-1eeb-9877-9f2416bff04c",
@@ -655,7 +686,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "7ded5b80-5b7d-1eeb-9877-9f2416bff04c",
@@ -667,7 +699,8 @@
           "quantityPerItem": 300,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.3
     },
     {
       "id": "cded1550-5cac-1eeb-9877-9f2416bff04c",
@@ -679,7 +712,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "4167ed50-5e44-1eeb-9877-9f2416bff04c",
@@ -691,7 +725,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.92
     },
     {
       "id": "d48c4d30-cc57-1098-91d0-51096b672064",
@@ -703,7 +738,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 1.09
     },
     {
       "id": "5ce86780-cd8a-1098-91d0-51096b672064",
@@ -715,7 +751,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.65
     },
     {
       "id": "8f5167b0-c155-10a4-855b-21d41fd3dece",
@@ -733,7 +770,8 @@
           "quantityPerItem": 25,
           "unit": "centiliters"
         }
-      ]
+      ],
+      "density": 0.99
     },
     {
       "id": "f4c3d230-c43f-10a4-855b-21d41fd3dece",
@@ -745,7 +783,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.9
     },
     {
       "id": "4c5aa3e0-c501-10a4-855b-21d41fd3dece",
@@ -758,7 +797,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "8c5caec0-c6a5-10a4-855b-21d41fd3dece",
@@ -770,7 +810,8 @@
           "quantityPerItem": 150,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.8
     },
     {
       "id": "040799a0-c9fd-10a7-a87d-2fef2dcd1072",
@@ -783,7 +824,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "ff90fa70-cf32-10a7-a87d-2fef2dcd1072",
@@ -802,7 +844,8 @@
           "unit": "grams",
           "shelfLifeDays": 7
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "ad070e70-d194-10a7-a87d-2fef2dcd1072",
@@ -815,7 +858,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.1
     },
     {
       "id": "ab8499c0-d32c-10a7-a87d-2fef2dcd1072",
@@ -834,7 +878,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 1.03
     },
     {
       "id": "5e717b40-d33f-10a7-a87d-2fef2dcd1072",
@@ -860,7 +905,8 @@
           "unit": "grams",
           "shelfLifeDays": 7
         }
-      ]
+      ],
+      "density": 0.95
     },
     {
       "id": "b3be0b30-43b3-10ba-b0dd-9d041637ca66",
@@ -872,7 +918,8 @@
           "quantityPerItem": 100,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.45
     },
     {
       "id": "e4bbbb00-6606-11ef-a13c-df814629faab",
@@ -884,7 +931,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.35
     },
     {
       "id": "2b038570-6607-11ef-a13c-df814629faab",
@@ -896,7 +944,8 @@
           "quantityPerItem": 300,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.6
     },
     {
       "id": "c8c654e0-6607-11ef-a13c-df814629faab",
@@ -916,7 +965,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "674fba50-6df8-11ef-bbaf-9d5832b648f8",
@@ -928,7 +978,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.9
     },
     {
       "id": "fc2a1cb0-6df8-11ef-bbaf-9d5832b648f8",
@@ -967,7 +1018,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.85
     },
     {
       "id": "5d213070-8277-11ef-91e8-3ff59147e22a",
@@ -979,7 +1031,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.85
     },
     {
       "id": "a3fcfd80-8277-11ef-91e8-3ff59147e22a",
@@ -999,7 +1052,8 @@
           "unit": "grams",
           "shelfLifeDays": 1
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "809e0220-8278-11ef-91e8-3ff59147e22a",
@@ -1024,7 +1078,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.8
     },
     {
       "id": "5acfd350-b862-11ef-b59c-79b6dddc8e34",
@@ -1036,7 +1091,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "7bca73e0-d5e4-11ef-8220-67ff092dbc1a",
@@ -1062,7 +1118,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "bcae79d0-dda8-11ef-99c9-5b6b5cdbe207",
@@ -1075,7 +1132,8 @@
           "unit": "grams",
           "shelfLifeDays": 2
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "5bbddb40-e17f-11ef-9727-9f4d05a6cf88",
@@ -1100,7 +1158,8 @@
           "quantityPerItem": 530,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "3bc3b7f4-5b8f-44af-844c-e16a0e2a086d",
@@ -1112,7 +1171,8 @@
           "quantityPerItem": 200,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "8ebac7b5-911b-40ae-a35a-6b2af3aa2d70",
@@ -1132,7 +1192,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.07
     },
     {
       "id": "354e837e-4698-4bb9-b434-7edb7b685fc0",
@@ -1150,7 +1211,8 @@
           "quantityPerItem": 250,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.8
     },
     {
       "id": "2cd926e5-7a02-49b5-a16e-8ef176b009e7",
@@ -1163,7 +1225,8 @@
           "unit": "grams",
           "shelfLifeDays": 1
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "8688350e-e38f-4a47-ad15-528ec384069f",
@@ -1175,7 +1238,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "3867ff41-f940-4c79-bf00-18bb2e0801f7",
@@ -1188,7 +1252,8 @@
           "unit": "grams",
           "shelfLifeDays": 5
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "0d635fd3-fd45-4d49-9d3c-11776be1ea6f",
@@ -1201,7 +1266,8 @@
           "unit": "grams",
           "shelfLifeDays": 3
         }
-      ]
+      ],
+      "density": 1.05
     },
     {
       "id": "40ea28e4-3537-4f7c-9623-01214c168ef3",
@@ -1227,7 +1293,8 @@
           "quantityPerItem": 500,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.55
     },
     {
       "id": "3daf3c1a-a192-4a72-aeaa-10171578f426",
@@ -1239,7 +1306,8 @@
           "quantityPerItem": 500,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.75
     },
     {
       "id": "fe71deee-e360-45ef-af6c-d6b64de852f2",
@@ -1251,7 +1319,8 @@
           "quantityPerItem": 1,
           "unit": "pieces"
         }
-      ]
+      ],
+      "density": 0.2
     },
     {
       "id": "07c401da-1af6-4a30-8f83-0f22fde011e4",
@@ -1263,7 +1332,8 @@
           "quantityPerItem": 125,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.5
     },
     {
       "id": "435b3e6a-6a14-4312-b02e-c905e806f234",
@@ -1276,7 +1346,8 @@
           "unit": "grams",
           "shelfLifeDays": 2
         }
-      ]
+      ],
+      "density": 1.0
     },
     {
       "id": "f013976c-649d-469e-a7e7-d04b5cb97a3b",
@@ -1288,7 +1359,8 @@
           "quantityPerItem": 1000,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.7
     },
     {
       "id": "d4e5f6a7-b8c9-0123-def0-123456789abc",
@@ -1300,7 +1372,8 @@
           "quantityPerItem": 450,
           "unit": "grams"
         }
-      ]
+      ],
+      "density": 0.75
     }
   ],
   "Recipes": [

--- a/menu_management/lib/ingredients/models/ingredient.dart
+++ b/menu_management/lib/ingredients/models/ingredient.dart
@@ -1,12 +1,42 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:menu_management/ingredients/models/product.dart";
+import "package:menu_management/recipes/enums/unit.dart";
+import "package:menu_management/recipes/models/quantity.dart";
 
 part "ingredient.freezed.dart";
 part "ingredient.g.dart";
 
 @freezed
 abstract class Ingredient with _$Ingredient {
-  const factory Ingredient({required String id, required String name, @Default([]) List<Product> products}) = _Ingredient;
+  const factory Ingredient({required String id, required String name, @Default([]) List<Product> products, @JsonKey(includeIfNull: false) double? density}) = _Ingredient;
 
   factory Ingredient.fromJson(Map<String, Object?> json) => _$IngredientFromJson(json);
+
+  const Ingredient._();
+
+  /// Converts a quantity to grams using this ingredient's density.
+  /// Returns null when conversion is not possible (no density, or unit is pieces).
+  double? toGrams(Quantity quantity) {
+    if (density == null) return null;
+    return switch (quantity.unit) {
+      Unit.grams => quantity.amount,
+      Unit.centiliters => quantity.amount * 10 * density!,
+      Unit.tablespoons => quantity.amount * 15 * density!,
+      Unit.teaspoons => quantity.amount * 5 * density!,
+      Unit.pieces => null,
+    };
+  }
+
+  /// Converts a gram amount back to the given unit using this ingredient's density.
+  /// Returns null when conversion is not possible (no density, or target is pieces).
+  double? fromGrams(double grams, Unit targetUnit) {
+    if (density == null) return null;
+    return switch (targetUnit) {
+      Unit.grams => grams,
+      Unit.centiliters => grams / (10 * density!),
+      Unit.tablespoons => grams / (15 * density!),
+      Unit.teaspoons => grams / (5 * density!),
+      Unit.pieces => null,
+    };
+  }
 }

--- a/menu_management/lib/ingredients/models/ingredient.freezed.dart
+++ b/menu_management/lib/ingredients/models/ingredient.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Ingredient {
 
- String get id; String get name; List<Product> get products;
+ String get id; String get name; List<Product> get products;@JsonKey(includeIfNull: false) double? get density;
 /// Create a copy of Ingredient
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $IngredientCopyWith<Ingredient> get copyWith => _$IngredientCopyWithImpl<Ingredi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Ingredient&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.products, products));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Ingredient&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.products, products)&&(identical(other.density, density) || other.density == density));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,const DeepCollectionEquality().hash(products));
+int get hashCode => Object.hash(runtimeType,id,name,const DeepCollectionEquality().hash(products),density);
 
 @override
 String toString() {
-  return 'Ingredient(id: $id, name: $name, products: $products)';
+  return 'Ingredient(id: $id, name: $name, products: $products, density: $density)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $IngredientCopyWith<$Res>  {
   factory $IngredientCopyWith(Ingredient value, $Res Function(Ingredient) _then) = _$IngredientCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, List<Product> products
+ String id, String name, List<Product> products,@JsonKey(includeIfNull: false) double? density
 });
 
 
@@ -65,12 +65,13 @@ class _$IngredientCopyWithImpl<$Res>
 
 /// Create a copy of Ingredient
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? products = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? products = null,Object? density = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,products: null == products ? _self.products : products // ignore: cast_nullable_to_non_nullable
-as List<Product>,
+as List<Product>,density: freezed == density ? _self.density : density // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  List<Product> products)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  List<Product> products, @JsonKey(includeIfNull: false)  double? density)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Ingredient() when $default != null:
-return $default(_that.id,_that.name,_that.products);case _:
+return $default(_that.id,_that.name,_that.products,_that.density);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.id,_that.name,_that.products);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  List<Product> products)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  List<Product> products, @JsonKey(includeIfNull: false)  double? density)  $default,) {final _that = this;
 switch (_that) {
 case _Ingredient():
-return $default(_that.id,_that.name,_that.products);case _:
+return $default(_that.id,_that.name,_that.products,_that.density);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.id,_that.name,_that.products);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  List<Product> products)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  List<Product> products, @JsonKey(includeIfNull: false)  double? density)?  $default,) {final _that = this;
 switch (_that) {
 case _Ingredient() when $default != null:
-return $default(_that.id,_that.name,_that.products);case _:
+return $default(_that.id,_that.name,_that.products,_that.density);case _:
   return null;
 
 }
@@ -210,8 +211,8 @@ return $default(_that.id,_that.name,_that.products);case _:
 /// @nodoc
 @JsonSerializable()
 
-class _Ingredient implements Ingredient {
-  const _Ingredient({required this.id, required this.name, final  List<Product> products = const []}): _products = products;
+class _Ingredient extends Ingredient {
+  const _Ingredient({required this.id, required this.name, final  List<Product> products = const [], @JsonKey(includeIfNull: false) this.density}): _products = products,super._();
   factory _Ingredient.fromJson(Map<String, dynamic> json) => _$IngredientFromJson(json);
 
 @override final  String id;
@@ -223,6 +224,7 @@ class _Ingredient implements Ingredient {
   return EqualUnmodifiableListView(_products);
 }
 
+@override@JsonKey(includeIfNull: false) final  double? density;
 
 /// Create a copy of Ingredient
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Ingredient&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._products, _products));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Ingredient&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._products, _products)&&(identical(other.density, density) || other.density == density));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,const DeepCollectionEquality().hash(_products));
+int get hashCode => Object.hash(runtimeType,id,name,const DeepCollectionEquality().hash(_products),density);
 
 @override
 String toString() {
-  return 'Ingredient(id: $id, name: $name, products: $products)';
+  return 'Ingredient(id: $id, name: $name, products: $products, density: $density)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$IngredientCopyWith<$Res> implements $IngredientCopyWith<$
   factory _$IngredientCopyWith(_Ingredient value, $Res Function(_Ingredient) _then) = __$IngredientCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, List<Product> products
+ String id, String name, List<Product> products,@JsonKey(includeIfNull: false) double? density
 });
 
 
@@ -274,12 +276,13 @@ class __$IngredientCopyWithImpl<$Res>
 
 /// Create a copy of Ingredient
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? products = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? products = null,Object? density = freezed,}) {
   return _then(_Ingredient(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,products: null == products ? _self._products : products // ignore: cast_nullable_to_non_nullable
-as List<Product>,
+as List<Product>,density: freezed == density ? _self.density : density // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 

--- a/menu_management/lib/ingredients/models/ingredient.g.dart
+++ b/menu_management/lib/ingredients/models/ingredient.g.dart
@@ -9,11 +9,18 @@ part of 'ingredient.dart';
 _Ingredient _$IngredientFromJson(Map<String, dynamic> json) => _Ingredient(
   id: json['id'] as String,
   name: json['name'] as String,
-  products: (json['products'] as List<dynamic>?)?.map((e) => Product.fromJson(e as Map<String, dynamic>)).toList() ?? const [],
+  products:
+      (json['products'] as List<dynamic>?)
+          ?.map((e) => Product.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+  density: (json['density'] as num?)?.toDouble(),
 );
 
-Map<String, dynamic> _$IngredientToJson(_Ingredient instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'products': instance.products,
-};
+Map<String, dynamic> _$IngredientToJson(_Ingredient instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'products': instance.products,
+      'density': ?instance.density,
+    };

--- a/menu_management/lib/ingredients/models/product.dart
+++ b/menu_management/lib/ingredients/models/product.dart
@@ -6,7 +6,7 @@ part "product.g.dart";
 
 @freezed
 abstract class Product with _$Product {
-  const factory Product({required String link, @Default(1) int itemsPerPack, required double quantityPerItem, required Unit unit}) = _Product;
+  const factory Product({required String link, @Default(1) int itemsPerPack, required double quantityPerItem, required Unit unit, @JsonKey(includeIfNull: false) int? shelfLifeDays}) = _Product;
 
   factory Product.fromJson(Map<String, Object?> json) => _$ProductFromJson(json);
 

--- a/menu_management/lib/ingredients/models/product.freezed.dart
+++ b/menu_management/lib/ingredients/models/product.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Product {
 
- String get link; int get itemsPerPack; double get quantityPerItem; Unit get unit;
+ String get link; int get itemsPerPack; double get quantityPerItem; Unit get unit;@JsonKey(includeIfNull: false) int? get shelfLifeDays;
 /// Create a copy of Product
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ProductCopyWith<Product> get copyWith => _$ProductCopyWithImpl<Product>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Product&&(identical(other.link, link) || other.link == link)&&(identical(other.itemsPerPack, itemsPerPack) || other.itemsPerPack == itemsPerPack)&&(identical(other.quantityPerItem, quantityPerItem) || other.quantityPerItem == quantityPerItem)&&(identical(other.unit, unit) || other.unit == unit));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Product&&(identical(other.link, link) || other.link == link)&&(identical(other.itemsPerPack, itemsPerPack) || other.itemsPerPack == itemsPerPack)&&(identical(other.quantityPerItem, quantityPerItem) || other.quantityPerItem == quantityPerItem)&&(identical(other.unit, unit) || other.unit == unit)&&(identical(other.shelfLifeDays, shelfLifeDays) || other.shelfLifeDays == shelfLifeDays));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,link,itemsPerPack,quantityPerItem,unit);
+int get hashCode => Object.hash(runtimeType,link,itemsPerPack,quantityPerItem,unit,shelfLifeDays);
 
 @override
 String toString() {
-  return 'Product(link: $link, itemsPerPack: $itemsPerPack, quantityPerItem: $quantityPerItem, unit: $unit)';
+  return 'Product(link: $link, itemsPerPack: $itemsPerPack, quantityPerItem: $quantityPerItem, unit: $unit, shelfLifeDays: $shelfLifeDays)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ProductCopyWith<$Res>  {
   factory $ProductCopyWith(Product value, $Res Function(Product) _then) = _$ProductCopyWithImpl;
 @useResult
 $Res call({
- String link, int itemsPerPack, double quantityPerItem, Unit unit
+ String link, int itemsPerPack, double quantityPerItem, Unit unit,@JsonKey(includeIfNull: false) int? shelfLifeDays
 });
 
 
@@ -65,13 +65,14 @@ class _$ProductCopyWithImpl<$Res>
 
 /// Create a copy of Product
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? link = null,Object? itemsPerPack = null,Object? quantityPerItem = null,Object? unit = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? link = null,Object? itemsPerPack = null,Object? quantityPerItem = null,Object? unit = null,Object? shelfLifeDays = freezed,}) {
   return _then(_self.copyWith(
 link: null == link ? _self.link : link // ignore: cast_nullable_to_non_nullable
 as String,itemsPerPack: null == itemsPerPack ? _self.itemsPerPack : itemsPerPack // ignore: cast_nullable_to_non_nullable
 as int,quantityPerItem: null == quantityPerItem ? _self.quantityPerItem : quantityPerItem // ignore: cast_nullable_to_non_nullable
 as double,unit: null == unit ? _self.unit : unit // ignore: cast_nullable_to_non_nullable
-as Unit,
+as Unit,shelfLifeDays: freezed == shelfLifeDays ? _self.shelfLifeDays : shelfLifeDays // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -156,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit, @JsonKey(includeIfNull: false)  int? shelfLifeDays)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Product() when $default != null:
-return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);case _:
+return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit,_that.shelfLifeDays);case _:
   return orElse();
 
 }
@@ -177,10 +178,10 @@ return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit, @JsonKey(includeIfNull: false)  int? shelfLifeDays)  $default,) {final _that = this;
 switch (_that) {
 case _Product():
-return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);case _:
+return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit,_that.shelfLifeDays);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -197,10 +198,10 @@ return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String link,  int itemsPerPack,  double quantityPerItem,  Unit unit, @JsonKey(includeIfNull: false)  int? shelfLifeDays)?  $default,) {final _that = this;
 switch (_that) {
 case _Product() when $default != null:
-return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);case _:
+return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit,_that.shelfLifeDays);case _:
   return null;
 
 }
@@ -212,13 +213,14 @@ return $default(_that.link,_that.itemsPerPack,_that.quantityPerItem,_that.unit);
 @JsonSerializable()
 
 class _Product extends Product {
-  const _Product({required this.link, this.itemsPerPack = 1, required this.quantityPerItem, required this.unit}): super._();
+  const _Product({required this.link, this.itemsPerPack = 1, required this.quantityPerItem, required this.unit, @JsonKey(includeIfNull: false) this.shelfLifeDays}): super._();
   factory _Product.fromJson(Map<String, dynamic> json) => _$ProductFromJson(json);
 
 @override final  String link;
 @override@JsonKey() final  int itemsPerPack;
 @override final  double quantityPerItem;
 @override final  Unit unit;
+@override@JsonKey(includeIfNull: false) final  int? shelfLifeDays;
 
 /// Create a copy of Product
 /// with the given fields replaced by the non-null parameter values.
@@ -233,16 +235,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Product&&(identical(other.link, link) || other.link == link)&&(identical(other.itemsPerPack, itemsPerPack) || other.itemsPerPack == itemsPerPack)&&(identical(other.quantityPerItem, quantityPerItem) || other.quantityPerItem == quantityPerItem)&&(identical(other.unit, unit) || other.unit == unit));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Product&&(identical(other.link, link) || other.link == link)&&(identical(other.itemsPerPack, itemsPerPack) || other.itemsPerPack == itemsPerPack)&&(identical(other.quantityPerItem, quantityPerItem) || other.quantityPerItem == quantityPerItem)&&(identical(other.unit, unit) || other.unit == unit)&&(identical(other.shelfLifeDays, shelfLifeDays) || other.shelfLifeDays == shelfLifeDays));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,link,itemsPerPack,quantityPerItem,unit);
+int get hashCode => Object.hash(runtimeType,link,itemsPerPack,quantityPerItem,unit,shelfLifeDays);
 
 @override
 String toString() {
-  return 'Product(link: $link, itemsPerPack: $itemsPerPack, quantityPerItem: $quantityPerItem, unit: $unit)';
+  return 'Product(link: $link, itemsPerPack: $itemsPerPack, quantityPerItem: $quantityPerItem, unit: $unit, shelfLifeDays: $shelfLifeDays)';
 }
 
 
@@ -253,7 +255,7 @@ abstract mixin class _$ProductCopyWith<$Res> implements $ProductCopyWith<$Res> {
   factory _$ProductCopyWith(_Product value, $Res Function(_Product) _then) = __$ProductCopyWithImpl;
 @override @useResult
 $Res call({
- String link, int itemsPerPack, double quantityPerItem, Unit unit
+ String link, int itemsPerPack, double quantityPerItem, Unit unit,@JsonKey(includeIfNull: false) int? shelfLifeDays
 });
 
 
@@ -270,13 +272,14 @@ class __$ProductCopyWithImpl<$Res>
 
 /// Create a copy of Product
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? link = null,Object? itemsPerPack = null,Object? quantityPerItem = null,Object? unit = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? link = null,Object? itemsPerPack = null,Object? quantityPerItem = null,Object? unit = null,Object? shelfLifeDays = freezed,}) {
   return _then(_Product(
 link: null == link ? _self.link : link // ignore: cast_nullable_to_non_nullable
 as String,itemsPerPack: null == itemsPerPack ? _self.itemsPerPack : itemsPerPack // ignore: cast_nullable_to_non_nullable
 as int,quantityPerItem: null == quantityPerItem ? _self.quantityPerItem : quantityPerItem // ignore: cast_nullable_to_non_nullable
 as double,unit: null == unit ? _self.unit : unit // ignore: cast_nullable_to_non_nullable
-as Unit,
+as Unit,shelfLifeDays: freezed == shelfLifeDays ? _self.shelfLifeDays : shelfLifeDays // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/menu_management/lib/ingredients/models/product.g.dart
+++ b/menu_management/lib/ingredients/models/product.g.dart
@@ -11,6 +11,7 @@ _Product _$ProductFromJson(Map<String, dynamic> json) => _Product(
   itemsPerPack: (json['itemsPerPack'] as num?)?.toInt() ?? 1,
   quantityPerItem: (json['quantityPerItem'] as num).toDouble(),
   unit: $enumDecode(_$UnitEnumMap, json['unit']),
+  shelfLifeDays: (json['shelfLifeDays'] as num?)?.toInt(),
 );
 
 Map<String, dynamic> _$ProductToJson(_Product instance) => <String, dynamic>{
@@ -18,6 +19,7 @@ Map<String, dynamic> _$ProductToJson(_Product instance) => <String, dynamic>{
   'itemsPerPack': instance.itemsPerPack,
   'quantityPerItem': instance.quantityPerItem,
   'unit': _$UnitEnumMap[instance.unit]!,
+  'shelfLifeDays': ?instance.shelfLifeDays,
 };
 
 const _$UnitEnumMap = {

--- a/menu_management/lib/ingredients/widgets/ingredient_name_editor.dart
+++ b/menu_management/lib/ingredients/widgets/ingredient_name_editor.dart
@@ -24,27 +24,42 @@ class IngredientNameEditor extends StatefulWidget {
 
 class _IngredientNameEditorState extends State<IngredientNameEditor> {
   late final TextEditingController _controller;
+  late final TextEditingController _densityController;
 
   @override
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.ingredient.name);
+    _densityController = TextEditingController(text: widget.ingredient.density?.toString() ?? "");
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _densityController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text("Edit Ingredient Name"),
-      content: TextField(
-        controller: _controller,
-        decoration: const InputDecoration(border: OutlineInputBorder(), labelText: "Ingredient Name"),
-        onChanged: (String value) => setState(() {}), // Trigger rebuild to update Save button state
+      title: const Text("Edit Ingredient"),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _controller,
+            decoration: const InputDecoration(border: OutlineInputBorder(), labelText: "Ingredient Name"),
+            onChanged: (String value) => setState(() {}),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _densityController,
+            decoration: const InputDecoration(border: OutlineInputBorder(), labelText: "Density (g/ml)", hintText: "e.g. 1.05 for yogurt, 0.91 for oil"),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            onChanged: (String value) => setState(() {}),
+          ),
+        ],
       ),
       actions: <Widget>[
         TextButton(
@@ -57,7 +72,8 @@ class _IngredientNameEditorState extends State<IngredientNameEditor> {
           onPressed: _controller.text.trimAndSetNullIfEmpty == null
               ? null
               : () {
-                  final Ingredient updatedIngredient = widget.ingredient.copyWith(name: _controller.text);
+                  double? density = double.tryParse(_densityController.text);
+                  final Ingredient updatedIngredient = widget.ingredient.copyWith(name: _controller.text, density: density);
                   widget.onUpdate(updatedIngredient);
                   IngredientsProvider.addOrUpdate(newIngredient: updatedIngredient);
                   Navigator.of(context).pop();

--- a/menu_management/lib/ingredients/widgets/product_editor.dart
+++ b/menu_management/lib/ingredients/widgets/product_editor.dart
@@ -31,6 +31,7 @@ class _ProductEditorState extends State<ProductEditor> {
   late final TextEditingController _linkController;
   late final TextEditingController _itemsPerPackController;
   late final TextEditingController _quantityPerItemController;
+  late final TextEditingController _shelfLifeDaysController;
   late Unit _selectedUnit;
 
   @override
@@ -40,6 +41,7 @@ class _ProductEditorState extends State<ProductEditor> {
     _linkController = TextEditingController();
     _itemsPerPackController = TextEditingController(text: "1");
     _quantityPerItemController = TextEditingController();
+    _shelfLifeDaysController = TextEditingController();
     _selectedUnit = Unit.grams;
   }
 
@@ -48,6 +50,7 @@ class _ProductEditorState extends State<ProductEditor> {
     _linkController.dispose();
     _itemsPerPackController.dispose();
     _quantityPerItemController.dispose();
+    _shelfLifeDaysController.dispose();
     super.dispose();
   }
 
@@ -56,6 +59,7 @@ class _ProductEditorState extends State<ProductEditor> {
     _linkController.text = product.link;
     _itemsPerPackController.text = product.itemsPerPack.toString();
     _quantityPerItemController.text = product.quantityPerItem.toString();
+    _shelfLifeDaysController.text = product.shelfLifeDays?.toString() ?? "";
     _selectedUnit = product.unit;
     setState(() => _editingIndex = index);
   }
@@ -64,6 +68,7 @@ class _ProductEditorState extends State<ProductEditor> {
     _linkController.clear();
     _itemsPerPackController.text = "1";
     _quantityPerItemController.clear();
+    _shelfLifeDaysController.clear();
     _selectedUnit = Unit.grams;
     setState(() => _editingIndex = null);
   }
@@ -87,11 +92,13 @@ class _ProductEditorState extends State<ProductEditor> {
   }
 
   Product _buildProductFromForm() {
+    int? shelfLifeDays = int.tryParse(_shelfLifeDaysController.text);
     return Product(
       link: _linkController.text.trim(),
       itemsPerPack: int.parse(_itemsPerPackController.text),
       quantityPerItem: double.parse(_quantityPerItemController.text),
       unit: _selectedUnit,
+      shelfLifeDays: shelfLifeDays,
     );
   }
 
@@ -191,6 +198,13 @@ class _ProductEditorState extends State<ProductEditor> {
               onChanged: (Unit? value) {
                 if (value != null) setState(() => _selectedUnit = value);
               },
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _shelfLifeDaysController,
+              decoration: const InputDecoration(border: OutlineInputBorder(), labelText: "Shelf life (days after opening)", hintText: "Leave empty for non-perishable"),
+              keyboardType: TextInputType.number,
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 12),
             Row(

--- a/menu_management/lib/menu/models/menu.g.dart
+++ b/menu_management/lib/menu/models/menu.g.dart
@@ -6,7 +6,14 @@ part of 'menu.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_Menu _$MenuFromJson(Map<String, dynamic> json) =>
-    _Menu(meals: (json['meals'] as List<dynamic>?)?.map((e) => Meal.fromJson(e as Map<String, dynamic>)).toList() ?? const []);
+_Menu _$MenuFromJson(Map<String, dynamic> json) => _Menu(
+  meals:
+      (json['meals'] as List<dynamic>?)
+          ?.map((e) => Meal.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+);
 
-Map<String, dynamic> _$MenuToJson(_Menu instance) => <String, dynamic>{'meals': instance.meals};
+Map<String, dynamic> _$MenuToJson(_Menu instance) => <String, dynamic>{
+  'meals': instance.meals,
+};

--- a/menu_management/lib/menu/models/multi_week_menu.g.dart
+++ b/menu_management/lib/menu/models/multi_week_menu.g.dart
@@ -7,6 +7,13 @@ part of 'multi_week_menu.dart';
 // **************************************************************************
 
 _MultiWeekMenu _$MultiWeekMenuFromJson(Map<String, dynamic> json) =>
-    _MultiWeekMenu(weeks: (json['weeks'] as List<dynamic>?)?.map((e) => Menu.fromJson(e as Map<String, dynamic>)).toList() ?? const []);
+    _MultiWeekMenu(
+      weeks:
+          (json['weeks'] as List<dynamic>?)
+              ?.map((e) => Menu.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
 
-Map<String, dynamic> _$MultiWeekMenuToJson(_MultiWeekMenu instance) => <String, dynamic>{'weeks': instance.weeks};
+Map<String, dynamic> _$MultiWeekMenuToJson(_MultiWeekMenu instance) =>
+    <String, dynamic>{'weeks': instance.weeks};

--- a/menu_management/lib/recipes/models/recipe.g.dart
+++ b/menu_management/lib/recipes/models/recipe.g.dart
@@ -9,11 +9,16 @@ part of 'recipe.dart';
 _Recipe _$RecipeFromJson(Map<String, dynamic> json) => _Recipe(
   id: json['id'] as String,
   name: json['name'] as String,
-  instructions: (json['instructions'] as List<dynamic>?)?.map((e) => Instruction.fromJson(e as Map<String, dynamic>)).toList() ?? const [],
+  instructions:
+      (json['instructions'] as List<dynamic>?)
+          ?.map((e) => Instruction.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
   carbs: json['carbs'] as bool? ?? true,
   proteins: json['proteins'] as bool? ?? true,
   vegetables: json['vegetables'] as bool? ?? true,
-  type: $enumDecodeNullable(_$RecipeTypeEnumMap, json['type']) ?? RecipeType.meal,
+  type:
+      $enumDecodeNullable(_$RecipeTypeEnumMap, json['type']) ?? RecipeType.meal,
   lunch: json['lunch'] as bool? ?? true,
   dinner: json['dinner'] as bool? ?? true,
   canBeStored: json['canBeStored'] as bool? ?? true,
@@ -34,4 +39,9 @@ Map<String, dynamic> _$RecipeToJson(_Recipe instance) => <String, dynamic>{
   'includeInMenuGeneration': instance.includeInMenuGeneration,
 };
 
-const _$RecipeTypeEnumMap = {RecipeType.breakfast: 'breakfast', RecipeType.meal: 'meal', RecipeType.snack: 'snack', RecipeType.dessert: 'dessert'};
+const _$RecipeTypeEnumMap = {
+  RecipeType.breakfast: 'breakfast',
+  RecipeType.meal: 'meal',
+  RecipeType.snack: 'snack',
+  RecipeType.dessert: 'dessert',
+};

--- a/menu_management/lib/shopping/quantity_normalizer.dart
+++ b/menu_management/lib/shopping/quantity_normalizer.dart
@@ -1,0 +1,114 @@
+import "package:menu_management/flutter_essentials/library.dart";
+import "package:menu_management/ingredients/models/ingredient.dart";
+import "package:menu_management/recipes/enums/unit.dart";
+import "package:menu_management/recipes/models/quantity.dart";
+
+/// Milliliters per unit for volume conversions (universal, no density needed).
+const Map<Unit, double> _mlPerUnit = {
+  Unit.centiliters: 10,
+  Unit.tablespoons: 15,
+  Unit.teaspoons: 5,
+};
+
+bool _isVolumeUnit(Unit unit) => _mlPerUnit.containsKey(unit);
+
+/// Normalizes a list of quantities for a single ingredient by merging
+/// compatible units. Volume units (tbsp, tsp, cl) are merged universally.
+/// If density is known, volume and weight are merged into grams.
+///
+/// Pieces are never merged with other units.
+List<Quantity> normalizeQuantities({required Ingredient ingredient, required List<Quantity> rawQuantities}) {
+  if (rawQuantities.isEmpty) return const [];
+  if (rawQuantities.length == 1 && (rawQuantities.first.unit == Unit.grams || rawQuantities.first.unit == Unit.pieces)) {
+    return rawQuantities;
+  }
+
+  // Separate pieces from weight/volume
+  final List<Quantity> pieces = rawQuantities.where((q) => q.unit == Unit.pieces).toList();
+  final List<Quantity> weightVolume = rawQuantities.where((q) => q.unit != Unit.pieces).toList();
+
+  if (weightVolume.isEmpty) return pieces;
+
+  // Sum all grams
+  double totalGrams = weightVolume.where((q) => q.unit == Unit.grams).fold(0.0, (sum, q) => sum + q.amount);
+
+  // Sum all volume as milliliters
+  double totalMl = weightVolume.where((q) => _isVolumeUnit(q.unit)).fold(0.0, (sum, q) => sum + q.amount * _mlPerUnit[q.unit]!);
+
+  bool hasGrams = weightVolume.any((q) => q.unit == Unit.grams);
+  bool hasVolume = weightVolume.any((q) => _isVolumeUnit(q.unit));
+
+  // Determine the target unit
+  Unit targetUnit = _determineTargetUnit(ingredient: ingredient, hasGrams: hasGrams, hasVolume: hasVolume);
+
+  if (targetUnit == Unit.grams) {
+    // Merge everything into grams
+    if (hasVolume && ingredient.density != null) {
+      totalGrams += totalMl * ingredient.density!;
+      totalMl = 0;
+    }
+
+    List<Quantity> result = [...pieces];
+    if (totalGrams > 0) result.add(Quantity(amount: totalGrams, unit: Unit.grams));
+    if (totalMl > 0) result.add(Quantity(amount: totalMl / 10, unit: Unit.centiliters)); // fallback: couldn't convert
+    return result;
+  }
+
+  if (targetUnit == Unit.centiliters) {
+    // Merge everything into centiliters
+    if (hasGrams && ingredient.density != null && ingredient.density! > 0) {
+      totalMl += totalGrams / ingredient.density!;
+      totalGrams = 0;
+    }
+
+    List<Quantity> result = [...pieces];
+    if (totalMl > 0) result.add(Quantity(amount: totalMl / 10, unit: Unit.centiliters));
+    if (totalGrams > 0) result.add(Quantity(amount: totalGrams, unit: Unit.grams)); // fallback: couldn't convert
+    return result;
+  }
+
+  // Should not reach here, but return original as safety net
+  return rawQuantities;
+}
+
+/// Determines what unit to normalize to, considering product units and density availability.
+Unit _determineTargetUnit({required Ingredient ingredient, required bool hasGrams, required bool hasVolume}) {
+  // If a product exists, prefer matching the product's unit
+  if (ingredient.products.isNotEmpty) {
+    Unit productUnit = ingredient.products.first.unit;
+    if (productUnit == Unit.grams && ingredient.density != null) return Unit.grams;
+    if (_isVolumeUnit(productUnit)) return Unit.centiliters;
+    // Product is in pieces or unknown; fall through to default logic
+  }
+
+  // Both weight and volume present
+  if (hasGrams && hasVolume) {
+    // If density is known, merge into grams (weight is the more useful shopping unit)
+    if (ingredient.density != null) return Unit.grams;
+    // No density: keep both families, volume merges to cl, grams stays
+    return Unit.grams; // grams won't merge volume without density; the function handles this
+  }
+
+  // Only grams
+  if (hasGrams) return Unit.grams;
+
+  // Only volume (tbsp, tsp, cl) - if density known and no products, convert to grams
+  if (hasVolume) {
+    if (ingredient.density != null && ingredient.products.isEmpty) return Unit.grams;
+    return Unit.centiliters;
+  }
+
+  return Unit.grams; // default
+}
+
+/// Normalizes an entire ingredients map by merging compatible units per ingredient.
+Map<String, List<Quantity>> normalizeAllIngredients({
+  required Map<String, List<Quantity>> rawQuantities,
+  required List<Ingredient> ingredients,
+}) {
+  return rawQuantities.map((String ingredientId, List<Quantity> quantities) {
+    Ingredient? ingredient = ingredients.firstWhereOrNull((i) => i.id == ingredientId);
+    if (ingredient == null) return MapEntry(ingredientId, quantities);
+    return MapEntry(ingredientId, normalizeQuantities(ingredient: ingredient, rawQuantities: quantities));
+  });
+}

--- a/menu_management/lib/shopping/shopping_ingredient.dart
+++ b/menu_management/lib/shopping/shopping_ingredient.dart
@@ -1,147 +1,203 @@
 import "package:flutter/material.dart";
 import "package:menu_management/flutter_essentials/library.dart";
 import "package:menu_management/ingredients/models/ingredient.dart";
+import "package:menu_management/ingredients/models/product.dart";
 import "package:menu_management/recipes/enums/unit.dart";
 import "package:menu_management/recipes/models/quantity.dart";
+import "package:menu_management/shopping/shopping_product_row.dart";
+import "package:menu_management/shopping/waste_optimizer.dart";
 
 class ShoppingIngredient extends StatelessWidget {
   const ShoppingIngredient({
     super.key,
     required this.ingredient,
     required this.quantitiesDesired,
-    required this.onOwnedAmountChanged,
-    required this.ownedQuantities,
     required this.calculatedRemainingQuantities,
+    required this.productRecommendations,
+    required this.ownedPacksPerProduct,
+    required this.ownedRaw,
+    required this.onPacksChanged,
+    required this.onRawOwnedChanged,
+    required this.dailyUsage,
   });
 
   final Ingredient ingredient;
   final List<Quantity> quantitiesDesired;
-  final List<Quantity> ownedQuantities;
-  final void Function(List<Quantity> newOwnedQuantities) onOwnedAmountChanged;
   final List<Quantity> calculatedRemainingQuantities;
+  final List<ProductRecommendation> productRecommendations;
+  final Map<int, double> ownedPacksPerProduct;
+  final List<Quantity> ownedRaw;
+  final void Function(int productIndex, double packs) onPacksChanged;
+  final void Function(List<Quantity> rawOwned) onRawOwnedChanged;
+  final double dailyUsage;
+
+  bool get _isFullyCovered => calculatedRemainingQuantities.every((q) => q.amount <= 0);
 
   @override
   Widget build(BuildContext context) {
+    // Find the best (first viable, or first overall) recommendation
+    int? bestProductIndex;
+    if (productRecommendations.length > 1) {
+      ProductRecommendation? bestViable = productRecommendations.firstWhereOrNull((r) => r.isViable);
+      ProductRecommendation best = bestViable ?? productRecommendations.first;
+      bestProductIndex = ingredient.products.indexOf(best.product);
+    }
+
     return OutlinedCard(
-      child: Row(
-        // mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          SizedBox(width: 350, child: Text(ingredient.name, style: Theme.of(context).textTheme.titleLarge)),
-          const SizedBox(width: 10),
-          Builder(
-            builder: (context) {
-              bool areAllRemainingQuantitiesZero = calculatedRemainingQuantities.every((quantity) => quantity.amount <= 0);
-              return FilledCard(
-                color: Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: areAllRemainingQuantitiesZero ? 0.1 : 1),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: quantitiesDesired.map((Quantity quantity) {
-                    String unit = quantity.unit.name;
-                    String displayText = _formatDesiredAmount(quantity);
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header: ingredient name + total remaining
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    ingredient.name,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(color: _isFullyCovered ? Theme.of(context).hintColor : null),
+                  ),
+                ),
+                ...calculatedRemainingQuantities.map((Quantity q) {
+                  if (q.amount <= 0) {
                     return Padding(
-                      padding: const EdgeInsets.all(4.0),
+                      padding: const EdgeInsets.only(left: 8),
                       child: Row(
-                        children: [
-                          SizedBox(width: 200, child: Text(displayText, style: Theme.of(context).textTheme.bodyLarge)),
-                          const SizedBox(width: 10),
-                          SizedBox(
-                            width: 220,
-                            child: TextFieldOwnedAmount(
-                              unit: unit,
-                              desiredAmount: quantity.amount,
-                              onOwnedAmountChanged: (value) => informOfOwnedQuantitiesWith(value, quantity.unit),
-                            ),
-                          ),
-                          const SizedBox(width: 10),
-                          SizedBox(
-                            width: 150,
-                            child: Row(
-                              children: [
-                                Text(
-                                  calculatedRemainingQuantities.firstWhere((q) => q.unit == quantity.unit).amount.toStringAsFixed(0),
-                                  style: Theme.of(context).textTheme.bodyLarge,
-                                ),
-                                Text(" $unit"),
-                              ],
-                            ),
-                          ),
-                        ],
+                        mainAxisSize: MainAxisSize.min,
+                        children: [Icon(Icons.check_rounded, color: Theme.of(context).hintColor, size: 18), const SizedBox(width: 4), Text("All set", style: TextStyle(color: Theme.of(context).hintColor))],
                       ),
                     );
-                  }).toList(),
-                ),
-              );
-            },
-          ),
-          const SizedBox(width: 10),
-        ],
+                  }
+                  return Padding(
+                    padding: const EdgeInsets.only(left: 8),
+                    child: Text("Need: ${q.amount.toStringAsFixed(0)} ${q.unit.name}", style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)),
+                  );
+                }),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            // Product rows (if products exist)
+            if (ingredient.products.isNotEmpty)
+              ...ingredient.products.asMap().entries.map((MapEntry<int, Product> entry) {
+                int productIndex = entry.key;
+                Product product = entry.value;
+
+                // Find recommendation for this product
+                ProductRecommendation recommendation = productRecommendations.firstWhere(
+                  (r) => r.product == product,
+                  orElse: () => ProductRecommendation(product: product, packsNeeded: 0, overBuyWaste: 0, expiryWaste: 0, isViable: true),
+                );
+
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: ShoppingProductRow(
+                    product: product,
+                    recommendation: recommendation,
+                    isRecommended: bestProductIndex == productIndex,
+                    ownedPacks: ownedPacksPerProduct[productIndex] ?? 0,
+                    onOwnedPacksChanged: (double packs) => onPacksChanged(productIndex, packs),
+                  ),
+                );
+              }),
+
+            // Raw unit fallback (no products)
+            if (ingredient.products.isEmpty)
+              ...quantitiesDesired.map((Quantity quantity) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: _NoProductRow(
+                    quantity: quantity,
+                    remainingAmount: calculatedRemainingQuantities.firstWhere((q) => q.unit == quantity.unit, orElse: () => Quantity(amount: 0, unit: quantity.unit)),
+                    ownedQuantity: ownedRaw.firstWhere((q) => q.unit == quantity.unit, orElse: () => Quantity(amount: 0, unit: quantity.unit)),
+                    onOwnedAmountChanged: (double value, Unit unit) {
+                      List<Quantity> newOwned = ownedRaw.map((q) => q.unit == unit ? Quantity(amount: value, unit: unit) : q).toList();
+                      onRawOwnedChanged(newOwned);
+                    },
+                  ),
+                );
+              }),
+          ],
+        ),
       ),
     );
   }
-
-  String _formatDesiredAmount(Quantity quantity) {
-    if (ingredient.products.isNotEmpty) {
-      return ingredient.products.first.formatQuantityForDisplay(quantity.amount, quantity.unit);
-    }
-    String amountRounded = quantity.amount.toStringAsFixed(0);
-    String unitName = quantity.unit.name;
-    return "$amountRounded $unitName";
-  }
-
-  void informOfOwnedQuantitiesWith(double newOwnedValue, Unit quantityUnit) {
-    List<Quantity> newQuantities = [];
-    for (Quantity q in ownedQuantities) {
-      if (q.unit == quantityUnit) {
-        q = Quantity(amount: newOwnedValue, unit: q.unit);
-      }
-      newQuantities.add(q);
-    }
-    onOwnedAmountChanged(newQuantities);
-  }
 }
 
-class TextFieldOwnedAmount extends StatefulWidget {
-  const TextFieldOwnedAmount({super.key, required this.unit, required this.desiredAmount, required this.onOwnedAmountChanged});
-  final String unit;
-  final double desiredAmount;
-  final void Function(double value) onOwnedAmountChanged;
+class _NoProductRow extends StatefulWidget {
+  const _NoProductRow({required this.quantity, required this.remainingAmount, required this.ownedQuantity, required this.onOwnedAmountChanged});
+
+  final Quantity quantity;
+  final Quantity remainingAmount;
+  final Quantity ownedQuantity;
+  final void Function(double value, Unit unit) onOwnedAmountChanged;
 
   @override
-  State<TextFieldOwnedAmount> createState() => _TextFieldOwnedAmountState();
+  State<_NoProductRow> createState() => _NoProductRowState();
 }
 
-class _TextFieldOwnedAmountState extends State<TextFieldOwnedAmount> {
-  late TextEditingController controller;
+class _NoProductRowState extends State<_NoProductRow> {
+  late TextEditingController _controller;
 
   @override
   void initState() {
     super.initState();
-    controller = TextEditingController();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      decoration: InputDecoration(
-        labelText: "Owned ${widget.unit}",
-        border: const OutlineInputBorder(),
-        suffixIcon: IconButton(
-          icon: const Icon(Icons.check_circle_rounded),
-          onPressed: () {
-            setState(() {
-              controller.text = widget.desiredAmount.toString();
-            });
-            widget.onOwnedAmountChanged(widget.desiredAmount);
-          },
+    String unit = widget.quantity.unit.name;
+    bool covered = widget.remainingAmount.amount <= 0;
+
+    return FilledCard(
+      color: Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: covered ? 0.3 : 1),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: Row(
+          children: [
+            SizedBox(width: 200, child: Text("${widget.quantity.amount.toStringAsFixed(0)} $unit", style: Theme.of(context).textTheme.bodyLarge)),
+            const SizedBox(width: 10),
+            SizedBox(
+              width: 200,
+              child: TextField(
+                controller: _controller,
+                decoration: InputDecoration(
+                  labelText: "Owned $unit",
+                  border: const OutlineInputBorder(),
+                  isDense: true,
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.check_circle_rounded, size: 20),
+                    onPressed: () {
+                      setState(() => _controller.text = widget.quantity.amount.toString());
+                      widget.onOwnedAmountChanged(widget.quantity.amount, widget.quantity.unit);
+                    },
+                  ),
+                ),
+                onChanged: (String value) {
+                  double? val = double.tryParse(value);
+                  if (value.isNullOrEmpty) val = 0;
+                  if (val == null) return;
+                  widget.onOwnedAmountChanged(val, widget.quantity.unit);
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            SizedBox(
+              width: 150,
+              child: covered
+                  ? Row(children: [Icon(Icons.check_rounded, color: Theme.of(context).hintColor, size: 18), const SizedBox(width: 4), Text("Covered", style: TextStyle(color: Theme.of(context).hintColor))])
+                  : Text("${widget.remainingAmount.amount.toStringAsFixed(0)} $unit remaining", style: Theme.of(context).textTheme.bodyLarge),
+            ),
+          ],
         ),
       ),
-      onChanged: (String value) {
-        double? val = double.tryParse(value);
-        if (value.isNullOrEmpty) val = 0;
-        if (val == null) return;
-        widget.onOwnedAmountChanged(val);
-      },
     );
   }
 }

--- a/menu_management/lib/shopping/shopping_page.dart
+++ b/menu_management/lib/shopping/shopping_page.dart
@@ -8,6 +8,7 @@ import "package:menu_management/ingredients/models/ingredient.dart";
 import "package:menu_management/menu/models/multi_week_menu.dart";
 import "package:menu_management/recipes/recipes_provider.dart";
 import "package:menu_management/recipes/models/quantity.dart";
+import "package:menu_management/shopping/quantity_normalizer.dart";
 import "package:menu_management/shopping/shopping_ingredient.dart";
 
 class ShoppingPage extends StatefulWidget {
@@ -26,7 +27,11 @@ class _ShoppingPageState extends State<ShoppingPage> {
   @override
   void initState() {
     super.initState();
-    ingredientsRequired = widget.multiWeekMenu.allIngredients(recipes: RecipesProvider.instance.recipes);
+    Map<String, List<Quantity>> rawIngredients = widget.multiWeekMenu.allIngredients(recipes: RecipesProvider.instance.recipes);
+    ingredientsRequired = normalizeAllIngredients(
+      rawQuantities: rawIngredients,
+      ingredients: IngredientsProvider.instance.ingredients,
+    );
     ingredientsOwned = ingredientsRequired.map(
       (key, value) => MapEntry(key, value.map((quantity) => Quantity(amount: 0, unit: quantity.unit)).toList()),
     );

--- a/menu_management/lib/shopping/shopping_page.dart
+++ b/menu_management/lib/shopping/shopping_page.dart
@@ -5,11 +5,13 @@ import "package:flutter/services.dart";
 import "package:menu_management/flutter_essentials/library.dart";
 import "package:menu_management/ingredients/ingredients_provider.dart";
 import "package:menu_management/ingredients/models/ingredient.dart";
+import "package:menu_management/ingredients/models/product.dart";
 import "package:menu_management/menu/models/multi_week_menu.dart";
 import "package:menu_management/recipes/recipes_provider.dart";
 import "package:menu_management/recipes/models/quantity.dart";
 import "package:menu_management/shopping/quantity_normalizer.dart";
 import "package:menu_management/shopping/shopping_ingredient.dart";
+import "package:menu_management/shopping/waste_optimizer.dart";
 
 class ShoppingPage extends StatefulWidget {
   const ShoppingPage({super.key, required this.multiWeekMenu});
@@ -22,19 +24,44 @@ class ShoppingPage extends StatefulWidget {
 
 class _ShoppingPageState extends State<ShoppingPage> {
   late final Map<String, List<Quantity>> ingredientsRequired;
-  late final Map<String, List<Quantity>> ingredientsOwned;
+
+  /// Per-product owned packs: ingredient ID -> product index -> owned packs (double).
+  late final Map<String, Map<int, double>> ownedPacksPerProduct;
+
+  /// Raw owned amounts for ingredients without products: ingredient ID to List of Quantity.
+  late final Map<String, List<Quantity>> ownedRawForNoProducts;
+
+  /// Daily usage per ingredient (total / consumption days, simplified to total / 7 for now).
+  late final Map<String, double> dailyUsagePerIngredient;
 
   @override
   void initState() {
     super.initState();
+    List<Ingredient> allIngredients = IngredientsProvider.instance.ingredients;
     Map<String, List<Quantity>> rawIngredients = widget.multiWeekMenu.allIngredients(recipes: RecipesProvider.instance.recipes);
-    ingredientsRequired = normalizeAllIngredients(
-      rawQuantities: rawIngredients,
-      ingredients: IngredientsProvider.instance.ingredients,
-    );
-    ingredientsOwned = ingredientsRequired.map(
-      (key, value) => MapEntry(key, value.map((quantity) => Quantity(amount: 0, unit: quantity.unit)).toList()),
-    );
+
+    ingredientsRequired = normalizeAllIngredients(rawQuantities: rawIngredients, ingredients: allIngredients);
+
+    ownedPacksPerProduct = {};
+    ownedRawForNoProducts = {};
+    dailyUsagePerIngredient = {};
+
+    int totalDays = widget.multiWeekMenu.weeks.length * 7;
+
+    for (MapEntry<String, List<Quantity>> entry in ingredientsRequired.entries) {
+      String ingredientId = entry.key;
+      Ingredient? ingredient = allIngredients.firstWhereOrNull((i) => i.id == ingredientId);
+
+      if (ingredient != null && ingredient.products.isNotEmpty) {
+        ownedPacksPerProduct[ingredientId] = {};
+      } else {
+        ownedRawForNoProducts[ingredientId] = entry.value.map((q) => Quantity(amount: 0, unit: q.unit)).toList();
+      }
+
+      // Compute daily usage: sum of all quantities in the first matching unit
+      double totalAmount = entry.value.fold(0.0, (sum, q) => sum + q.amount);
+      dailyUsagePerIngredient[ingredientId] = totalDays > 0 ? totalAmount / totalDays : totalAmount;
+    }
   }
 
   @override
@@ -43,42 +70,43 @@ class _ShoppingPageState extends State<ShoppingPage> {
       appBar: AppBar(title: const Text("Shopping List")),
       floatingActionButton: FloatingActionButton(
         tooltip: "Copy to clipboard",
-        onPressed: () {
-          // Create string (ignoring those with required <= 0). Format: "Ingredient: N packs (X unit) + amount unit + ..."
-          String shoppingList = ingredientsRequired.entries
-              .map((entry) {
-                List<Quantity> remaining = remainingAmounts(ingredient: entry.key);
-                if (!remaining.any((quantity) => quantity.amount > 0)) return null;
-                Ingredient ingredient = IngredientsProvider.instance.get(entry.key);
-                String amounts = remaining
-                    .where((quantity) => quantity.amount > 0)
-                    .map((Quantity quantity) {
-                      if (ingredient.products.isNotEmpty) {
-                        return ingredient.products.first.formatQuantityForDisplay(quantity.amount, quantity.unit);
-                      }
-                      String unitName = quantity.unit.name;
-                      return "${quantity.amount.toStringAsFixed(0)} $unitName";
-                    })
-                    .join(" + ");
-                return "${ingredient.name}: $amounts";
-              })
-              .whereNotNull()
-              .join("\n");
-          // Copy to clipboard
-          Clipboard.setData(ClipboardData(text: shoppingList));
-        },
+        onPressed: _copyToClipboard,
         child: const Icon(Icons.copy_rounded),
       ),
       body: ListView.builder(
         itemCount: ingredientsRequired.length,
         itemBuilder: (context, index) {
+          String ingredientId = ingredientsRequired.keyAt(index);
+          Ingredient ingredient = getProvider<IngredientsProvider>(context, listen: true).get(ingredientId);
+          List<Quantity> desired = ingredientsRequired.valueAt(index);
+          List<Quantity> remaining = _remainingAmounts(ingredientId: ingredientId, ingredient: ingredient);
+          double dailyUsage = dailyUsagePerIngredient[ingredientId] ?? 0;
+
+          // Compute product recommendations
+          List<ProductRecommendation> recommendations = [];
+          if (ingredient.products.isNotEmpty && desired.isNotEmpty) {
+            // Use the first quantity's amount and unit for recommendations (after normalization, usually just 1)
+            Quantity primaryQuantity = desired.first;
+            List<Product> matchingProducts = ingredient.products.where((p) => p.unit == primaryQuantity.unit).toList();
+            recommendations = rankProducts(totalNeeded: primaryQuantity.amount, dailyUsage: dailyUsage, products: matchingProducts);
+          }
+
           return ShoppingIngredient(
-            ingredient: getProvider<IngredientsProvider>(context, listen: true).get(ingredientsRequired.keyAt(index)),
-            quantitiesDesired: ingredientsRequired.valueAt(index),
-            ownedQuantities: ingredientsOwned[ingredientsRequired.keyAt(index)]!,
-            calculatedRemainingQuantities: remainingAmounts(ingredient: ingredientsRequired.keyAt(index)),
-            onOwnedAmountChanged: (List<Quantity> ownedQuantities) {
-              setState(() => ingredientsOwned[ingredientsRequired.keyAt(index)] = ownedQuantities);
+            ingredient: ingredient,
+            quantitiesDesired: desired,
+            calculatedRemainingQuantities: remaining,
+            productRecommendations: recommendations,
+            ownedPacksPerProduct: ownedPacksPerProduct[ingredientId] ?? {},
+            ownedRaw: ownedRawForNoProducts[ingredientId] ?? desired.map((q) => Quantity(amount: 0, unit: q.unit)).toList(),
+            dailyUsage: dailyUsage,
+            onPacksChanged: (int productIndex, double packs) {
+              setState(() {
+                ownedPacksPerProduct[ingredientId] ??= {};
+                ownedPacksPerProduct[ingredientId]![productIndex] = packs;
+              });
+            },
+            onRawOwnedChanged: (List<Quantity> rawOwned) {
+              setState(() => ownedRawForNoProducts[ingredientId] = rawOwned);
             },
           );
         },
@@ -86,15 +114,65 @@ class _ShoppingPageState extends State<ShoppingPage> {
     );
   }
 
-  List<Quantity> remainingAmounts({required String ingredient}) {
-    int ingredientIndex = ingredientsRequired.keys.toList().indexOf(ingredient);
-    List<Quantity> required = ingredientsRequired.valueAt(ingredientIndex);
-    List<Quantity> owned = ingredientsOwned[ingredientsRequired.keyAt(ingredientIndex)]!;
+  List<Quantity> _remainingAmounts({required String ingredientId, required Ingredient ingredient}) {
+    List<Quantity> required = ingredientsRequired[ingredientId]!;
 
-    return required.map((quantityRequired) {
-      Quantity ownedQuantity = owned.firstWhere((ownedQty) => ownedQty.unit == quantityRequired.unit);
+    if (ingredient.products.isNotEmpty) {
+      // Compute total owned amount from pack data
+      Map<int, double> ownedPacks = ownedPacksPerProduct[ingredientId] ?? {};
+
+      return required.map((Quantity quantityRequired) {
+        // Sum owned across all products with matching unit
+        double totalOwned = 0;
+        for (MapEntry<int, double> entry in ownedPacks.entries) {
+          if (entry.key < ingredient.products.length) {
+            Product product = ingredient.products[entry.key];
+            if (product.unit == quantityRequired.unit) {
+              totalOwned += entry.value * product.totalQuantityPerPack;
+            }
+          }
+        }
+        double amount = quantityRequired.amount - totalOwned;
+        return Quantity(amount: max(0, amount).roundToDouble(), unit: quantityRequired.unit);
+      }).toList();
+    }
+
+    // No products: use raw owned amounts
+    List<Quantity> owned = ownedRawForNoProducts[ingredientId] ?? [];
+    return required.map((Quantity quantityRequired) {
+      Quantity ownedQuantity = owned.firstWhere((o) => o.unit == quantityRequired.unit, orElse: () => Quantity(amount: 0, unit: quantityRequired.unit));
       double amount = quantityRequired.amount - ownedQuantity.amount;
       return Quantity(amount: max(0, amount).roundToDouble(), unit: quantityRequired.unit);
     }).toList();
+  }
+
+  void _copyToClipboard() {
+    StringBuffer buffer = StringBuffer();
+
+    for (MapEntry<String, List<Quantity>> entry in ingredientsRequired.entries) {
+      String ingredientId = entry.key;
+      Ingredient ingredient = IngredientsProvider.instance.get(ingredientId);
+      List<Quantity> remaining = _remainingAmounts(ingredientId: ingredientId, ingredient: ingredient);
+
+      if (!remaining.any((q) => q.amount > 0)) continue;
+
+      if (ingredient.products.isNotEmpty) {
+        buffer.writeln(ingredient.name);
+        Quantity primaryRemaining = remaining.firstWhere((q) => q.amount > 0);
+        for (Product product in ingredient.products) {
+          if (product.unit != primaryRemaining.unit) continue;
+          int packs = product.packsNeeded(primaryRemaining.amount);
+          if (packs <= 0) continue;
+          String packLabel = "${product.itemsPerPack}x${product.quantityPerItem.toStringAsFixed(0)}${product.unit.name}";
+          String packWord = packs == 1 ? "pack" : "packs";
+          buffer.writeln("  $packLabel: $packs $packWord");
+        }
+      } else {
+        String amounts = remaining.where((q) => q.amount > 0).map((q) => "${q.amount.toStringAsFixed(0)} ${q.unit.name}").join(" + ");
+        buffer.writeln("${ingredient.name}: $amounts");
+      }
+    }
+
+    Clipboard.setData(ClipboardData(text: buffer.toString().trimRight()));
   }
 }

--- a/menu_management/lib/shopping/shopping_product_row.dart
+++ b/menu_management/lib/shopping/shopping_product_row.dart
@@ -1,0 +1,150 @@
+import "dart:io";
+
+import "package:flutter/material.dart";
+import "package:menu_management/flutter_essentials/library.dart";
+import "package:menu_management/ingredients/models/product.dart";
+import "package:menu_management/shopping/waste_optimizer.dart";
+import "package:menu_management/theme/theme_custom.dart";
+
+class ShoppingProductRow extends StatefulWidget {
+  const ShoppingProductRow({
+    super.key,
+    required this.product,
+    required this.recommendation,
+    required this.isRecommended,
+    required this.ownedPacks,
+    required this.onOwnedPacksChanged,
+  });
+
+  final Product product;
+  final ProductRecommendation recommendation;
+  final bool isRecommended;
+  final double ownedPacks;
+  final void Function(double packs) onOwnedPacksChanged;
+
+  @override
+  State<ShoppingProductRow> createState() => _ShoppingProductRowState();
+}
+
+class _ShoppingProductRowState extends State<ShoppingProductRow> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  int get _packsToBuy {
+    double ownedAmount = widget.ownedPacks * widget.product.totalQuantityPerPack;
+    double remaining = widget.recommendation.packsNeeded * widget.product.totalQuantityPerPack - ownedAmount;
+    if (remaining <= 0) return 0;
+    return (remaining / widget.product.totalQuantityPerPack).ceil();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String packLabel = "${widget.product.itemsPerPack}x${widget.product.quantityPerItem.toStringAsFixed(0)}${widget.product.unit.name}";
+    String totalLabel = "${widget.product.totalQuantityPerPack.toStringAsFixed(0)} ${widget.product.unit.name}/pack";
+    int packsToBuy = _packsToBuy;
+    bool covered = packsToBuy <= 0;
+
+    return FilledCard(
+      outlined: true,
+      borderColor: widget.isRecommended ? ThemeCustom.colorScheme(context).tertiary : null,
+      color: ThemeCustom.colorScheme(context).secondaryContainer.withValues(alpha: covered ? 0.3 : 1),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: Row(
+          children: [
+            // Pack description
+            SizedBox(
+              width: 160,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(packLabel, style: Theme.of(context).textTheme.bodyLarge),
+                  Text(totalLabel, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Theme.of(context).hintColor)),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+
+            // Recommendation chip
+            if (widget.isRecommended)
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Chip(
+                  label: const Text("Best value"),
+                  backgroundColor: ThemeCustom.colorScheme(context).tertiaryContainer,
+                  labelStyle: TextStyle(color: ThemeCustom.colorScheme(context).onTertiaryContainer, fontSize: 12),
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                ),
+              ),
+
+            if (!widget.recommendation.isViable && widget.product.shelfLifeDays != null)
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Tooltip(
+                  message: "Expires in ${widget.product.shelfLifeDays} days after opening",
+                  child: Icon(Icons.warning_amber_rounded, color: ThemeCustom.colorScheme(context).error, size: 20),
+                ),
+              ),
+
+            // Owned packs input
+            SizedBox(
+              width: 160,
+              child: TextField(
+                controller: _controller,
+                decoration: InputDecoration(
+                  labelText: "Owned packs",
+                  hintText: "0.5 = half",
+                  border: const OutlineInputBorder(),
+                  isDense: true,
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.check_circle_rounded, size: 20),
+                    onPressed: () {
+                      double needed = widget.recommendation.packsNeeded.toDouble();
+                      setState(() => _controller.text = needed.toStringAsFixed(needed == needed.roundToDouble() ? 0 : 1));
+                      widget.onOwnedPacksChanged(needed);
+                    },
+                  ),
+                ),
+                onChanged: (String value) {
+                  double? val = double.tryParse(value);
+                  if (value.isNullOrEmpty) val = 0;
+                  if (val == null) return;
+                  widget.onOwnedPacksChanged(val);
+                },
+              ),
+            ),
+            const SizedBox(width: 12),
+
+            // Packs to buy
+            SizedBox(
+              width: 80,
+              child: covered
+                  ? Row(children: [Icon(Icons.check_rounded, color: Theme.of(context).hintColor, size: 18), const SizedBox(width: 4), Text("Covered", style: TextStyle(color: Theme.of(context).hintColor))])
+                  : Text("Buy $packsToBuy", style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(width: 8),
+
+            // Product link button
+            IconButton(
+              icon: const Icon(Icons.open_in_new_rounded, size: 20),
+              tooltip: "Open product page",
+              onPressed: widget.product.link.isEmpty ? null : () => Process.run("start", [widget.product.link], runInShell: true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/menu_management/lib/shopping/waste_optimizer.dart
+++ b/menu_management/lib/shopping/waste_optimizer.dart
@@ -1,0 +1,76 @@
+import "package:menu_management/ingredients/models/product.dart";
+
+class ProductRecommendation {
+  const ProductRecommendation({
+    required this.product,
+    required this.packsNeeded,
+    required this.overBuyWaste,
+    required this.expiryWaste,
+    required this.isViable,
+  });
+
+  final Product product;
+  final int packsNeeded;
+  final double overBuyWaste;
+  final double expiryWaste;
+  final bool isViable;
+
+  double get totalWaste => overBuyWaste + expiryWaste;
+}
+
+/// Ranks products by total waste (over-buy + expiry) for a given required amount.
+///
+/// [totalNeeded] is the total amount needed in the product's unit.
+/// [dailyUsage] is how much is consumed per day (for expiry calculations).
+/// [products] is the list of available products to compare.
+///
+/// Returns recommendations sorted by total waste (lowest first).
+/// The first viable product (isViable == true) is the recommended pick.
+List<ProductRecommendation> rankProducts({
+  required double totalNeeded,
+  required double dailyUsage,
+  required List<Product> products,
+}) {
+  if (products.isEmpty) return const [];
+
+  List<ProductRecommendation> recommendations = products.map((Product product) {
+    int packs = product.packsNeeded(totalNeeded);
+    double bought = packs * product.totalQuantityPerPack;
+    double overBuyWaste = bought - totalNeeded;
+    double expiryWaste = 0;
+    bool viable = true;
+
+    int? shelfLife = product.shelfLifeDays;
+
+    if (shelfLife != null && dailyUsage > 0 && packs > 0) {
+      if (product.itemsPerPack > 1) {
+        // Sealed individual items: each is opened independently
+        double daysToConsumeItem = product.quantityPerItem / dailyUsage;
+        if (daysToConsumeItem > shelfLife) {
+          double wastePerItem = product.quantityPerItem - dailyUsage * shelfLife;
+          expiryWaste = wastePerItem.clamp(0.0, product.quantityPerItem) * packs * product.itemsPerPack;
+          viable = false;
+        }
+      } else {
+        // Single container: whole pack opens at once
+        double daysToConsumePack = product.totalQuantityPerPack / dailyUsage;
+        if (daysToConsumePack > shelfLife) {
+          double wastePer = product.totalQuantityPerPack - dailyUsage * shelfLife;
+          expiryWaste = wastePer.clamp(0.0, product.totalQuantityPerPack) * packs;
+          viable = false;
+        }
+      }
+    }
+
+    return ProductRecommendation(
+      product: product,
+      packsNeeded: packs,
+      overBuyWaste: overBuyWaste,
+      expiryWaste: expiryWaste,
+      isViable: viable,
+    );
+  }).toList();
+
+  recommendations.sort((a, b) => a.totalWaste.compareTo(b.totalWaste));
+  return recommendations;
+}

--- a/menu_management/test/product_test.dart
+++ b/menu_management/test/product_test.dart
@@ -4,14 +4,16 @@ import "package:flutter_test/flutter_test.dart";
 import "package:menu_management/ingredients/models/ingredient.dart";
 import "package:menu_management/ingredients/models/product.dart";
 import "package:menu_management/recipes/enums/unit.dart";
+import "package:menu_management/recipes/models/quantity.dart";
 
 Product _product({
   String link = "https://tienda.mercadona.es/product/test",
   int itemsPerPack = 1,
   double quantityPerItem = 250,
   Unit unit = Unit.grams,
+  int? shelfLifeDays,
 }) {
-  return Product(link: link, itemsPerPack: itemsPerPack, quantityPerItem: quantityPerItem, unit: unit);
+  return Product(link: link, itemsPerPack: itemsPerPack, quantityPerItem: quantityPerItem, unit: unit, shelfLifeDays: shelfLifeDays);
 }
 
 void main() {
@@ -185,6 +187,162 @@ void main() {
         expect(restored.name, "Rice");
         expect(restored.products, isEmpty);
       });
+
+      test("deserializes old JSON without density field", () {
+        Map<String, dynamic> oldJson = {"id": "i1", "name": "Rice"};
+        Ingredient restored = Ingredient.fromJson(oldJson);
+        expect(restored.density, isNull);
+      });
+
+      test("round-trips with density", () {
+        Ingredient original = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        String encoded = jsonEncode(original.toJson());
+        Ingredient restored = Ingredient.fromJson(jsonDecode(encoded));
+        expect(restored.density, 1.05);
+      });
+
+      test("omits density from JSON when null", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Rice");
+        Map<String, dynamic> json = ingredient.toJson();
+        expect(json.containsKey("density"), isFalse);
+      });
+    });
+
+    group("density field", () {
+      test("defaults to null when not provided", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Rice");
+        expect(ingredient.density, isNull);
+      });
+
+      test("stores density when provided", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        expect(ingredient.density, 1.05);
+      });
+
+      test("copyWith can set density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Oil");
+        Ingredient updated = ingredient.copyWith(density: 0.92);
+        expect(updated.density, 0.92);
+      });
+    });
+
+    group("toGrams", () {
+      test("returns amount unchanged for grams", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        double? result = ingredient.toGrams(const Quantity(amount: 500, unit: Unit.grams));
+        expect(result, 500);
+      });
+
+      test("converts centiliters to grams using density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        // 10 cl = 100 ml, 100 ml * 1.05 g/ml = 105 g
+        double? result = ingredient.toGrams(const Quantity(amount: 10, unit: Unit.centiliters));
+        expect(result, 105);
+      });
+
+      test("converts tablespoons to grams using density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Oil", density: 0.92);
+        // 1 tbsp = 15 ml, 15 ml * 0.92 g/ml = 13.8 g
+        double? result = ingredient.toGrams(const Quantity(amount: 1, unit: Unit.tablespoons));
+        expect(result, closeTo(13.8, 0.001));
+      });
+
+      test("converts teaspoons to grams using density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Salt", density: 2.16);
+        // 1 tsp = 5 ml, 5 ml * 2.16 g/ml = 10.8 g
+        double? result = ingredient.toGrams(const Quantity(amount: 1, unit: Unit.teaspoons));
+        expect(result, closeTo(10.8, 0.001));
+      });
+
+      test("returns null for pieces", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Egg", density: 1.0);
+        double? result = ingredient.toGrams(const Quantity(amount: 6, unit: Unit.pieces));
+        expect(result, isNull);
+      });
+
+      test("returns null when density is null", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Rice");
+        double? result = ingredient.toGrams(const Quantity(amount: 100, unit: Unit.centiliters));
+        expect(result, isNull);
+      });
+
+      test("converts 72 tablespoons of yogurt correctly", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogur Griego", density: 1.05);
+        // 72 tbsp = 72 * 15 ml = 1080 ml, 1080 * 1.05 = 1134 g
+        double? result = ingredient.toGrams(const Quantity(amount: 72, unit: Unit.tablespoons));
+        expect(result, closeTo(1134, 0.001));
+      });
+    });
+
+    group("fromGrams", () {
+      test("returns grams unchanged", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        double? result = ingredient.fromGrams(500, Unit.grams);
+        expect(result, 500);
+      });
+
+      test("converts grams to centiliters using density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Yogurt", density: 1.05);
+        // 105 g / (10 ml/cl * 1.05 g/ml) = 10 cl
+        double? result = ingredient.fromGrams(105, Unit.centiliters);
+        expect(result, closeTo(10, 0.001));
+      });
+
+      test("converts grams to tablespoons using density", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Oil", density: 0.92);
+        // 13.8 g / (15 ml/tbsp * 0.92 g/ml) = 1 tbsp
+        double? result = ingredient.fromGrams(13.8, Unit.tablespoons);
+        expect(result, closeTo(1, 0.001));
+      });
+
+      test("returns null for pieces", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Egg", density: 1.0);
+        double? result = ingredient.fromGrams(500, Unit.pieces);
+        expect(result, isNull);
+      });
+
+      test("returns null when density is null", () {
+        Ingredient ingredient = const Ingredient(id: "i1", name: "Rice");
+        double? result = ingredient.fromGrams(500, Unit.centiliters);
+        expect(result, isNull);
+      });
+    });
+  });
+
+  // ── Product shelfLifeDays ──
+
+  group("Product shelfLifeDays", () {
+    test("defaults to null when not provided", () {
+      Product product = _product();
+      expect(product.shelfLifeDays, isNull);
+    });
+
+    test("stores shelfLifeDays when provided", () {
+      Product product = _product(shelfLifeDays: 3);
+      expect(product.shelfLifeDays, 3);
+    });
+
+    test("round-trips through JSON with shelfLifeDays", () {
+      Product original = _product(shelfLifeDays: 5);
+      String encoded = jsonEncode(original.toJson());
+      Product restored = Product.fromJson(jsonDecode(encoded));
+      expect(restored.shelfLifeDays, 5);
+    });
+
+    test("deserializes old JSON without shelfLifeDays", () {
+      Map<String, dynamic> oldJson = {
+        "link": "https://example.com",
+        "quantityPerItem": 250.0,
+        "unit": "grams",
+      };
+      Product restored = Product.fromJson(oldJson);
+      expect(restored.shelfLifeDays, isNull);
+    });
+
+    test("omits shelfLifeDays from JSON when null", () {
+      Product product = _product();
+      Map<String, dynamic> json = product.toJson();
+      expect(json.containsKey("shelfLifeDays"), isFalse);
     });
   });
 }

--- a/menu_management/test/quantity_normalizer_test.dart
+++ b/menu_management/test/quantity_normalizer_test.dart
@@ -1,0 +1,214 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:menu_management/ingredients/models/ingredient.dart";
+import "package:menu_management/ingredients/models/product.dart";
+import "package:menu_management/recipes/enums/unit.dart";
+import "package:menu_management/recipes/models/quantity.dart";
+import "package:menu_management/shopping/quantity_normalizer.dart";
+
+void main() {
+  group("normalizeQuantities", () {
+    group("same-family volume merging (no density needed)", () {
+      test("merges tablespoons and centiliters into centiliters", () {
+        // 12 tbsp = 18 cl, plus 400 cl = 418 cl
+        Ingredient oil = const Ingredient(id: "oil", name: "Aceite de Girasol");
+        List<Quantity> raw = const [Quantity(amount: 400, unit: Unit.centiliters), Quantity(amount: 12, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: oil, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.centiliters);
+        expect(result.first.amount, closeTo(418, 0.01));
+      });
+
+      test("merges teaspoons and tablespoons into centiliters", () {
+        // 2 tbsp = 3 cl, 6 tsp = 3 cl => 6 cl
+        Ingredient vinegar = const Ingredient(id: "v", name: "Vinagre");
+        List<Quantity> raw = const [Quantity(amount: 2, unit: Unit.tablespoons), Quantity(amount: 6, unit: Unit.teaspoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: vinegar, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.centiliters);
+        expect(result.first.amount, closeTo(6, 0.01));
+      });
+
+      test("single volume unit stays in centiliters after normalization", () {
+        Ingredient oil = const Ingredient(id: "o", name: "Oil");
+        List<Quantity> raw = const [Quantity(amount: 4, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: oil, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.centiliters);
+        expect(result.first.amount, closeTo(6, 0.01)); // 4 tbsp = 6 cl
+      });
+    });
+
+    group("cross-family merging with density", () {
+      test("merges tablespoons into grams when density is known", () {
+        // 72 tbsp of yogurt: 72 * 15ml * 1.05 g/ml = 1134g
+        Ingredient yogurt = const Ingredient(id: "y", name: "Yogur Griego", density: 1.05);
+        List<Quantity> raw = const [Quantity(amount: 72, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: yogurt, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.grams);
+        expect(result.first.amount, closeTo(1134, 0.1));
+      });
+
+      test("merges grams and tablespoons into grams when density is known", () {
+        // 500g + 3 tbsp (3*15*1.05 = 47.25g) = 547.25g
+        Ingredient yogurt = const Ingredient(id: "y", name: "Yogur", density: 1.05);
+        List<Quantity> raw = const [Quantity(amount: 500, unit: Unit.grams), Quantity(amount: 3, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: yogurt, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.grams);
+        expect(result.first.amount, closeTo(547.25, 0.1));
+      });
+
+      test("merges centiliters and grams into grams when density is known", () {
+        // 10 cl = 100ml * 1.07 = 107g, plus 200g = 307g
+        Ingredient tomato = const Ingredient(id: "t", name: "Tomate Triturado", density: 1.07);
+        List<Quantity> raw = const [Quantity(amount: 200, unit: Unit.grams), Quantity(amount: 10, unit: Unit.centiliters)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: tomato, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.grams);
+        expect(result.first.amount, closeTo(307, 0.1));
+      });
+    });
+
+    group("no density, mixed families", () {
+      test("keeps grams and tablespoons separate when density is null", () {
+        Ingredient unknown = const Ingredient(id: "u", name: "Unknown");
+        List<Quantity> raw = const [Quantity(amount: 200, unit: Unit.grams), Quantity(amount: 3, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: unknown, rawQuantities: raw);
+
+        expect(result.length, 2);
+        expect(result.any((q) => q.unit == Unit.grams && q.amount == 200), isTrue);
+        // tablespoons converted to centiliters even without density
+        Quantity clQuantity = result.firstWhere((q) => q.unit == Unit.centiliters);
+        expect(clQuantity.amount, closeTo(4.5, 0.01));
+      });
+    });
+
+    group("pieces", () {
+      test("pieces are never merged with other units", () {
+        Ingredient egg = const Ingredient(id: "e", name: "Egg", density: 1.0);
+        List<Quantity> raw = const [Quantity(amount: 6, unit: Unit.pieces), Quantity(amount: 100, unit: Unit.grams)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: egg, rawQuantities: raw);
+
+        expect(result.length, 2);
+        expect(result.any((q) => q.unit == Unit.pieces && q.amount == 6), isTrue);
+        expect(result.any((q) => q.unit == Unit.grams && q.amount == 100), isTrue);
+      });
+
+      test("pieces alone pass through unchanged", () {
+        Ingredient egg = const Ingredient(id: "e", name: "Egg");
+        List<Quantity> raw = const [Quantity(amount: 12, unit: Unit.pieces)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: egg, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first, const Quantity(amount: 12, unit: Unit.pieces));
+      });
+    });
+
+    group("single unit pass-through", () {
+      test("single grams quantity passes through unchanged", () {
+        Ingredient rice = const Ingredient(id: "r", name: "Rice");
+        List<Quantity> raw = const [Quantity(amount: 500, unit: Unit.grams)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: rice, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first, const Quantity(amount: 500, unit: Unit.grams));
+      });
+
+      test("single centiliters quantity passes through unchanged", () {
+        Ingredient milk = const Ingredient(id: "m", name: "Milk");
+        List<Quantity> raw = const [Quantity(amount: 100, unit: Unit.centiliters)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: milk, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first, const Quantity(amount: 100, unit: Unit.centiliters));
+      });
+    });
+
+    group("empty input", () {
+      test("returns empty list for empty input", () {
+        Ingredient any = const Ingredient(id: "a", name: "Any");
+        List<Quantity> result = normalizeQuantities(ingredient: any, rawQuantities: const []);
+        expect(result, isEmpty);
+      });
+    });
+
+    group("target unit selection based on products", () {
+      test("converts volume to grams when product is in grams and density is known", () {
+        // Yogurt product is in grams, recipe uses tablespoons
+        Ingredient yogurt = Ingredient(
+          id: "y",
+          name: "Yogur",
+          density: 1.05,
+          products: [const Product(link: "https://example.com", quantityPerItem: 125, unit: Unit.grams, itemsPerPack: 6)],
+        );
+        List<Quantity> raw = const [Quantity(amount: 10, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: yogurt, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.grams);
+        // 10 tbsp * 15ml * 1.05 = 157.5g
+        expect(result.first.amount, closeTo(157.5, 0.1));
+      });
+
+      test("keeps centiliters when product is in centiliters", () {
+        Ingredient oil = Ingredient(
+          id: "o",
+          name: "Oil",
+          density: 0.91,
+          products: [const Product(link: "https://example.com", quantityPerItem: 100, unit: Unit.centiliters)],
+        );
+        List<Quantity> raw = const [Quantity(amount: 6, unit: Unit.tablespoons)];
+
+        List<Quantity> result = normalizeQuantities(ingredient: oil, rawQuantities: raw);
+
+        expect(result.length, 1);
+        expect(result.first.unit, Unit.centiliters);
+        expect(result.first.amount, closeTo(9, 0.01)); // 6 tbsp = 9 cl
+      });
+    });
+  });
+
+  group("normalizeAllIngredients", () {
+    test("normalizes a full ingredients map", () {
+      Ingredient yogurt = const Ingredient(id: "y", name: "Yogur Griego", density: 1.05);
+      Ingredient oil = const Ingredient(id: "o", name: "Oil");
+
+      Map<String, List<Quantity>> raw = {
+        "y": const [Quantity(amount: 72, unit: Unit.tablespoons)],
+        "o": const [Quantity(amount: 400, unit: Unit.centiliters), Quantity(amount: 12, unit: Unit.tablespoons)],
+      };
+      List<Ingredient> ingredients = [yogurt, oil];
+
+      Map<String, List<Quantity>> result = normalizeAllIngredients(rawQuantities: raw, ingredients: ingredients);
+
+      // Yogurt: 72 tbsp -> grams (density known, no product but default to grams)
+      expect(result["y"]!.length, 1);
+      expect(result["y"]!.first.unit, Unit.grams);
+      expect(result["y"]!.first.amount, closeTo(1134, 0.1));
+
+      // Oil: 400cl + 12tbsp -> merged centiliters (no density, same family)
+      expect(result["o"]!.length, 1);
+      expect(result["o"]!.first.unit, Unit.centiliters);
+      expect(result["o"]!.first.amount, closeTo(418, 0.01));
+    });
+  });
+}

--- a/menu_management/test/waste_optimizer_test.dart
+++ b/menu_management/test/waste_optimizer_test.dart
@@ -1,0 +1,151 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:menu_management/ingredients/models/product.dart";
+import "package:menu_management/recipes/enums/unit.dart";
+import "package:menu_management/shopping/waste_optimizer.dart";
+
+Product _product({
+  double quantityPerItem = 250,
+  int itemsPerPack = 1,
+  Unit unit = Unit.grams,
+  int? shelfLifeDays,
+}) {
+  return Product(link: "https://example.com", quantityPerItem: quantityPerItem, itemsPerPack: itemsPerPack, unit: unit, shelfLifeDays: shelfLifeDays);
+}
+
+void main() {
+  group("rankProducts", () {
+    group("over-buy waste only (no shelf life)", () {
+      test("recommends product with least over-buy waste", () {
+        // Need 500g. Small: 6x100g=600g (100g waste). Big: 1x1000g (500g waste).
+        Product small = _product(quantityPerItem: 100, itemsPerPack: 6);
+        Product big = _product(quantityPerItem: 1000);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: [big, small]);
+
+        expect(result.first.product, small);
+        expect(result.first.packsNeeded, 1);
+        expect(result.first.overBuyWaste, closeTo(100, 0.01));
+        expect(result.first.totalWaste, closeTo(100, 0.01));
+      });
+
+      test("recommends exact-fit product with zero waste", () {
+        Product exact = _product(quantityPerItem: 500);
+        Product oversized = _product(quantityPerItem: 750);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: [oversized, exact]);
+
+        expect(result.first.product, exact);
+        expect(result.first.totalWaste, closeTo(0, 0.01));
+      });
+
+      test("handles multiple packs needed", () {
+        // Need 1200g. Product: 1x500g -> 3 packs = 1500g, 300g waste
+        Product product = _product(quantityPerItem: 500);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 1200, dailyUsage: 200, products: [product]);
+
+        expect(result.first.packsNeeded, 3);
+        expect(result.first.overBuyWaste, closeTo(300, 0.01));
+      });
+    });
+
+    group("expiry waste for single containers (itemsPerPack == 1)", () {
+      test("flags waste when container expires before consumed", () {
+        // Need 500g. Product: 1x500g, shelfLifeDays=3. Daily usage=100g.
+        // Can consume 300g in 3 days, wastes 200g per pack.
+        Product product = _product(quantityPerItem: 500, shelfLifeDays: 3);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: [product]);
+
+        expect(result.first.expiryWaste, closeTo(200, 0.01));
+        expect(result.first.isViable, isFalse);
+      });
+
+      test("no expiry waste when daily usage is high enough", () {
+        // Need 500g. Product: 1x500g, shelfLifeDays=5. Daily usage=100g.
+        // Can consume 500g in 5 days. No expiry waste.
+        Product product = _product(quantityPerItem: 500, shelfLifeDays: 5);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: [product]);
+
+        expect(result.first.expiryWaste, closeTo(0, 0.01));
+        expect(result.first.isViable, isTrue);
+      });
+
+      test("no expiry waste when shelfLifeDays is null (non-perishable)", () {
+        Product product = _product(quantityPerItem: 500);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 10, products: [product]);
+
+        expect(result.first.expiryWaste, closeTo(0, 0.01));
+        expect(result.first.isViable, isTrue);
+      });
+    });
+
+    group("expiry waste for sealed-item packs (itemsPerPack > 1)", () {
+      test("no expiry waste when individual items are consumed within shelf life", () {
+        // 6x125g yogurt cups, shelfLifeDays=5. Daily usage=125g.
+        // Each cup consumed in 1 day (< 5 days). No waste.
+        Product product = _product(quantityPerItem: 125, itemsPerPack: 6, shelfLifeDays: 5);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 700, dailyUsage: 125, products: [product]);
+
+        expect(result.first.expiryWaste, closeTo(0, 0.01));
+        expect(result.first.isViable, isTrue);
+      });
+
+      test("flags waste when individual item takes too long to consume", () {
+        // 1x500g bucket, shelfLifeDays=3, daily=100g. Takes 5 days to consume. Waste: 200g.
+        // vs 6x125g cups, shelfLifeDays=3, daily=100g. Each cup takes 1.25 days. No waste.
+        Product bucket = _product(quantityPerItem: 500, itemsPerPack: 1, shelfLifeDays: 3);
+        Product cups = _product(quantityPerItem: 125, itemsPerPack: 6, shelfLifeDays: 3);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 700, dailyUsage: 100, products: [bucket, cups]);
+
+        // Cups should be recommended (less waste)
+        expect(result.first.product, cups);
+        expect(result.first.isViable, isTrue);
+
+        // Bucket has expiry waste
+        ProductRecommendation bucketRec = result.firstWhere((r) => r.product == bucket);
+        expect(bucketRec.isViable, isFalse);
+        expect(bucketRec.expiryWaste, greaterThan(0));
+      });
+    });
+
+    group("edge cases", () {
+      test("returns empty list for empty products", () {
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: []);
+        expect(result, isEmpty);
+      });
+
+      test("handles zero daily usage gracefully", () {
+        Product product = _product(quantityPerItem: 500, shelfLifeDays: 3);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 0, products: [product]);
+
+        expect(result.length, 1);
+        expect(result.first.packsNeeded, 1);
+      });
+
+      test("handles zero totalNeeded", () {
+        Product product = _product(quantityPerItem: 500);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 0, dailyUsage: 100, products: [product]);
+
+        expect(result.first.packsNeeded, 0);
+        expect(result.first.totalWaste, closeTo(0, 0.01));
+      });
+
+      test("single product returns that product", () {
+        Product only = _product(quantityPerItem: 300);
+
+        List<ProductRecommendation> result = rankProducts(totalNeeded: 500, dailyUsage: 100, products: [only]);
+
+        expect(result.length, 1);
+        expect(result.first.product, only);
+        expect(result.first.packsNeeded, 2);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Unit conversion**: Ingredient `density` field (g/ml) enables merging mixed units. "72 tablespoons" of yogurt becomes "1134 grams"; "400cl + 12tbsp" of oil becomes "418cl"
- **Waste optimization**: `rankProducts()` scores each product by over-buy + expiry waste, recommending the size that minimizes waste based on daily usage and shelf life
- **Multi-product shopping UI**: Each ingredient shows all available products with pack info, "Best value" chip, expiry warnings, owned-packs input, and clickable product URLs
- **Data population**: 23 ingredients populated with density values, 33 products with shelf life data from Mercadona API
- **Editor support**: Density field in ingredient editor, shelf life field in product editor

## Test plan

- [x] 355 tests passing (27 new: 15 normalizer, 12 waste optimizer)
- [x] `flutter analyze` reports 0 issues
- [ ] Manual: generate a menu, open shopping list, verify "72 tablespoons" is now shown in grams
- [ ] Manual: verify multi-product ingredients show all products with "Best value" chip
- [ ] Manual: enter owned packs, verify remaining/to-buy updates correctly
- [ ] Manual: click copy button, verify output format shows per-product packs
- [ ] Manual: edit an ingredient, verify density field appears and persists
- [ ] Manual: edit a product, verify shelf life field appears and persists

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)